### PR TITLE
Add support for the Druid Dreamwalker trait. Fixes #29

### DIFF
--- a/src/Parser/RestoDruid/CombatLogParser.js
+++ b/src/Parser/RestoDruid/CombatLogParser.js
@@ -43,6 +43,7 @@ import TreeOfLife from './Modules/Features/TreeOfLife';
 import Flourish from './Modules/Features/Flourish';
 import Innervate from './Modules/Features/Innervate';
 import PowerOfTheArchdruid from './Modules/Features/PowerOfTheArchdruid';
+import Dreamwalker from './Modules/Features/Dreamwalker';
 
 import CPM_ABILITIES, { SPELL_CATEGORY } from './CPM_ABILITIES';
 
@@ -86,6 +87,7 @@ class CombatLogParser extends MainCombatLogParser {
     flourish: Flourish,
     innervate: Innervate,
     powerOfTheArchdruid: PowerOfTheArchdruid,
+    dreamwalker: Dreamwalker,
 
     // Legendaries:
     drapeOfShame: DrapeOfShame,
@@ -309,6 +311,15 @@ class CombatLogParser extends MainCombatLogParser {
         value={`${formatPercentage(efflorescenceUptime)} %`}
         label='Efflorescence uptime'
       />,
+      this.modules.dreamwalker.hasTrait && (
+      <StatisticBox icon={<SpellIcon id={SPELLS.DREAMWALKER.id}/>}
+        value={`${formatNumber(this.modules.dreamwalker.healing)}`}
+                    label={(
+                      <dfn data-tip={`The total healing done by Dreamwalker recorded was ${formatThousands(this.modules.dreamwalker.healing)} / ${formatPercentage(this.modules.dreamwalker.healing / this.totalHealing)} % / ${formatNumber(this.modules.dreamwalker.healing / fightDuration * 1000)} HPS. `}>
+                        Dreamwalker
+                      </dfn>
+                    )}
+      />),
       this.modules.powerOfTheArchdruid.hasTrait && (
         <StatisticBox
           icon={<SpellIcon id={SPELLS.POWER_OF_THE_ARCHDRUID.id} />}

--- a/src/Parser/RestoDruid/Modules/Features/Dreamwalker.js
+++ b/src/Parser/RestoDruid/Modules/Features/Dreamwalker.js
@@ -1,0 +1,27 @@
+import Module from 'Parser/Core/Module';
+import SPELLS from 'common/SPELLS';
+
+class Dreamwalker extends Module {
+
+  healing = 0;
+  hasTrait = false;
+  on_initialized() {
+    if (!this.owner.error) {
+      if(this.owner.selectedCombatant.traitsBySpellId[SPELLS.DREAMWALKER_TRAIT.id]>0) {
+        this.hasTrait = true;
+      }
+    }
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (SPELLS.DREAMWALKER.id !== spellId) {
+      return;
+    }
+    this.healing += event.amount;
+  }
+
+}
+
+export default Dreamwalker;

--- a/src/Parser/RestoDruid/README.md
+++ b/src/Parser/RestoDruid/README.md
@@ -18,7 +18,7 @@
 | [Sephuz's Secret](https://github.com/buimichael/RestoDruidAnalyzer/blob/master/src/Main/Parser/Modules/Legendaries/Velens.js) | The average haste gain from both status and procc and calculate throughput. This assumes that 1 haste rating = 1 int.| 90% |
 | [Tearstone of Elune](https://github.com/buimichael/RestoDruidAnalyzer/blob/master/src/Main/Parser/Modules/Legendaries/Velens.js) | Counts the amounts of free rejuvs gained (and procchance). Calculates throughput by checking the throughput from 1 rejuvenation and multiplying with the amounts of free rejuvenations gained. | 70-90% |
 | [X'oni's Caress](https://github.com/buimichael/RestoDruidAnalyzer/blob/master/src/Main/Parser/Modules/Legendaries/Velens.js) | The healing contributed by the iron bark effect. Doesn't take into consideration of the reduced iron bark CD. | 90% |
-
+| [Dreamwalker](https://github.com/MartijnHols/WoWAnalyzer/tree/master/src/Parser/RestoDruid/Modules/Features/Dreamwalker.js) | Calculates the amount healed by Dreamwalker. | 100% |
 The accuracy percentages assume there are no bugs in the implementation, the accuracy as of right now is not yet verified.
 ## Suggestions
 


### PR DESCRIPTION
This makes Dreamwalker show up on the Analyzer.

The result is the following:
![image](https://cloud.githubusercontent.com/assets/95754/26568954/53b364aa-44d5-11e7-9663-7ccf4549581d.png)
