### PR TITLE
(feature) Add support for talent descriptions with multiple specs.

### DIFF
--- a/src/Main/Talents.js
+++ b/src/Main/Talents.js
@@ -4,13 +4,22 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 
-const Talent = ({ talent }) => {
+const Talent = ({ talent, spec }) => {
   if (!talent) {
     return <i>No talent selected.</i>;
   }
 
   if (!SPELLS[talent]) {
     return <i>Talent not recognized: {talent}</i>;
+  }
+
+  let descriptionHtml = ''
+  if (typeof SPELLS[talent].description === 'string') {
+    descriptionHtml = SPELLS[talent].description
+  } else {
+    if (SPELLS[talent].description && SPELLS[talent].description[spec]) {
+      descriptionHtml = SPELLS[talent].description[spec]
+    }
   }
 
   return (
@@ -22,13 +31,14 @@ const Talent = ({ talent }) => {
         <header>
           <SpellLink id={talent} />
         </header>
-        <main dangerouslySetInnerHTML={{ __html: SPELLS[talent].description }} />
+        <main dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
       </div>
     </article>
   );
 };
 Talent.propTypes = {
   talent: React.PropTypes.number,
+  spec: React.PropTypes.number
 };
 
 const Talents = ({ combatant }) => {
@@ -42,25 +52,25 @@ const Talents = ({ combatant }) => {
     <div style={{ marginTop: -10, marginBottom: -10 }}>
       <ul className="list">
         <li className="item clearfix">
-          <Talent talent={combatant.lv15Talent} />
+          <Talent talent={combatant.lv15Talent} spec={combatant._combatantInfo.specID} />
         </li>
         <li className="item clearfix">
-          <Talent talent={combatant.lv30Talent} />
+          <Talent talent={combatant.lv30Talent} spec={combatant._combatantInfo.specID} />
         </li>
         <li className="item clearfix">
-          <Talent talent={combatant.lv45Talent} />
+          <Talent talent={combatant.lv45Talent} spec={combatant._combatantInfo.specID} />
         </li>
         <li className="item clearfix">
-          <Talent talent={combatant.lv60Talent} />
+          <Talent talent={combatant.lv60Talent} spec={combatant._combatantInfo.specID} />
         </li>
         <li className="item clearfix">
-          <Talent talent={combatant.lv75Talent} />
+          <Talent talent={combatant.lv75Talent} spec={combatant._combatantInfo.specID} />
         </li>
         <li className="item clearfix">
-          <Talent talent={combatant.lv90Talent} />
+          <Talent talent={combatant.lv90Talent} spec={combatant._combatantInfo.specID} />
         </li>
         <li className="item clearfix">
-          <Talent talent={combatant.lv100Talent} />
+          <Talent talent={combatant.lv100Talent} spec={combatant._combatantInfo.specID} />
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Examples
[Echo of the Elements](http://www.wowhead.com/spell=108283)
[Ancestral Guidance](http://www.wowhead.com/spell=108281)

New format for spells/talents if multiple specs are supported or need different descriptions:
```js
export default {
// ...
  ANCESTRAL_GUIDANCE_TALENT: {
    id: 108281,
    name: 'Ancestral Guidance',
    icon: 'ability_shaman_ancestralguidance',
    description: {
      262: '...', // Description for elemental shamans
      264: 'The default choice in this tier. ...' // Description for restoration shamans
    }
  }
// ...
}
```
