### PR TITLE
Updated Cooldown Tab & components to be able to represent damage as well as healing

### DIFF
--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -28,7 +28,8 @@ class Cooldown extends React.Component {
   static propTypes = {
     fightStart: React.PropTypes.number.isRequired,
     fightEnd: React.PropTypes.number.isRequired,
-    showHealingDone: React.PropTypes.bool,
+    ShowStatistics: React.PropTypes.bool,
+    showResourceStatistics: React.PropTypes.bool,
     cooldown: React.PropTypes.shape({
       ability: React.PropTypes.shape({
         id: React.PropTypes.number.isRequired,
@@ -51,6 +52,7 @@ class Cooldown extends React.Component {
     };
     this.handleExpandClick = this.handleExpandClick.bind(this);
     this.handleShowHealsClick = this.handleShowHealsClick.bind(this);
+    this.calculateHealingStatistics = this.calculateHealingStatistics.bind(this);
   }
 
   handleExpandClick() {
@@ -92,17 +94,38 @@ class Cooldown extends React.Component {
     return results;
   }
 
-  render() {
-    const { cooldown, fightStart, fightEnd, showHealingDone } = this.props;
-
-    let healingDone = 0;
-    let overhealingDone = 0;
-    showHealingDone && cooldown.events.filter(event => event.type === 'heal' || event.type === 'absorbed').forEach((event) => {
+  calculateHealingStatistics(cooldown) {
+    let healingDone = 0, overhealingDone = 0
+    cooldown.events.filter(event => event.type === 'heal' || event.type === 'absorbed').forEach((event) => {
       healingDone += event.amount + (event.absorbed || 0);
       overhealingDone += event.overheal || 0;
     });
-    const mana = cooldown.events.filter(event => event.type === 'cast').reduce((mana, event) => mana + (event.manaCost || 0), 0);
 
+    return {
+      healingDone,
+      overhealingDone
+    };
+  }
+
+  calculateDamageStatistics(cooldown) {
+    let damageDone = 0;
+    cooldown.events.reduce((damageDone , nextEvent) => damageDone + nextEvent.amount)
+    return {damageDone}
+  }
+  
+  render() {
+    const { cooldown, fightStart, fightEnd, showOutputStatistics, showResourceStatistics } = this.props;
+
+    let outputStatistics, resourceStatistics;
+
+    if (showOutputStatistics) {
+      outputStatistics = cooldown.ability.cooldownType === 'HEALING' ? this.calculateHealingStatistics(cooldown) : this.calculateDamageStatistics(cooldown);
+    }
+    if (showResourceStatistics) {
+      resourceStatistics = cooldown.events.filter(event => event.type === 'cast').reduce((mana, event) => mana + (event.manaCost || 0), 0);
+    }
+    
+    
     const start = cooldown.start;
     const end = cooldown.end || fightEnd;
 
@@ -114,7 +137,7 @@ class Cooldown extends React.Component {
           <SpellIcon id={cooldown.ability.id} />
         </figure>
         <div className="row" style={{ width: '100%' }}>
-          <div className={showHealingDone ? 'col-md-6' : 'col-md-10'}>
+          <div className={showOutputStatistics ? 'col-md-6' : 'col-md-10'}>
             <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
               <SpellLink id={cooldown.ability.id} /> ({formatDuration((start - fightStart) / 1000)} -&gt; {formatDuration((end - fightStart) / 1000)})
             </header>
@@ -166,22 +189,42 @@ class Cooldown extends React.Component {
               </div>
             )}
           </div>
-          {showHealingDone && (
-            <div className="col-md-2 text-center">
-              <div style={{ fontSize: '2em' }}>{formatNumber(healingDone)}</div>
-              <dfn data-tip="This includes all healing the occured while the buff was up, even if it was not triggered by spells cast inside the buff duration. Any delayed healing such as HOTs, Absorbs and Atonements will stop contributing to the healing done when the cooldown buff expires, so this value is lower for any specs with such abilities.">healing ({formatNumber(healingDone / (end - start) * 1000)} HPS)</dfn>
-            </div>
-          )}
-          {showHealingDone && (
-            <div className="col-md-2 text-center">
-              <div style={{ fontSize: '2em' }}>{formatPercentage(overhealingDone / (healingDone + overhealingDone))}%</div>
-              <dfn data-tip="This includes all healing the occured while the buff was up, even if it was not triggered by spells cast inside the buff duration. Any delayed healing such as HOTs, Absorbs and Atonements will stop contributing to the healing done when the cooldown buff expires, so this value is lower for any specs with such abilities.">overhealing</dfn>
-            </div>
-          )}
-          <div className="col-md-2 text-center">
-            <div style={{ fontSize: '2em' }}>{formatNumber(mana)}</div>
-            mana used
-          </div>
+          {
+            cooldown.ability.cooldownType === 'HEALING' && showOutputStatistics && (
+              <div>
+                <div className="col-md-2 text-center">
+                  <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.healingDone)}</div>
+                  <dfn data-tip="This includes all healing the occured while the buff was up, even if it was not triggered by spells cast inside the buff duration. Any delayed healing such as HOTs, Absorbs and Atonements will stop contributing to the healing done when the cooldown buff expires, so this value is lower for any specs with such abilities.">healing ({formatNumber(outputStatistics.healingDone / (end - start) * 1000)} HPS)</dfn>
+                </div>
+                <div className="col-md-2 text-center">
+                  <div style={{ fontSize: '2em' }}>{formatPercentage(outputStatistics.overhealingDone / (outputStatistics.healingDone + outputStatistics.overhealingDone))}%</div>
+                  <dfn data-tip="This includes all healing the occured while the buff was up, even if it was not triggered by spells cast inside the buff duration. Any delayed healing such as HOTs, Absorbs and Atonements will stop contributing to the healing done when the cooldown buff expires, so this value is lower for any specs with such abilities.">overhealing</dfn>
+                </div>
+              </div>
+            )
+          }  
+          {
+            cooldown.ability.cooldownType === 'DAMAGE' && showOutputStatistics && (
+              <div>
+                <div className="col-md-2 text-center">
+                  <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone)}</div>
+                  <dfn data-tip="This number represents the total amount of damage done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">Damage ({formatNumber(outputStatistics.damageDone / (end - start) * 1000)} DPS)</dfn>
+                </div>
+                {/*<div className="col-md-2 text-center">
+                  <div style={{ fontSize: '2em' }}>{formatPercentage(outputStatistics.overhealingDone / (outputStatistics.healingDone + outputStatistics.overhealingDone))}%</div>
+                  <dfn data-tip="This includes all healing the occured while the buff was up, even if it was not triggered by spells cast inside the buff duration. Any delayed healing such as HOTs, Absorbs and Atonements will stop contributing to the healing done when the cooldown buff expires, so this value is lower for any specs with such abilities.">overhealing</dfn>
+                </div>*/}
+              </div>
+            )
+          }             
+          {
+            showResourceStatistics && (
+              <div className="col-md-2 text-center">
+                <div style={{ fontSize: '2em' }}>{formatNumber(resourceStatistics)}</div>
+                mana used
+              </div>
+            )
+          }
         </div>
       </article>
     );

--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -52,7 +52,6 @@ class Cooldown extends React.Component {
     };
     this.handleExpandClick = this.handleExpandClick.bind(this);
     this.handleShowHealsClick = this.handleShowHealsClick.bind(this);
-    this.calculateHealingStatistics = this.calculateHealingStatistics.bind(this);
   }
 
   handleExpandClick() {

--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -108,8 +108,10 @@ class Cooldown extends React.Component {
   }
 
   calculateDamageStatistics(cooldown) {
-    let damageDone = 0;
-    cooldown.events.reduce((damageDone , nextEvent) => damageDone + nextEvent.amount)
+    let damageDone = cooldown.events.reduce((acc, event) => {
+      return event.type === 'damage' ? acc + event.amount : acc
+    }, 0)
+    
     return {damageDone}
   }
   
@@ -207,12 +209,12 @@ class Cooldown extends React.Component {
               <div>
                 <div className="col-md-2 text-center">
                   <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone)}</div>
-                  <dfn data-tip="This number represents the total amount of damage done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">Damage ({formatNumber(outputStatistics.damageDone / (end - start) * 1000)} DPS)</dfn>
+                  <dfn data-tip="This number represents the total amount of damage done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">Damage Done</dfn>
                 </div>
-                {/*<div className="col-md-2 text-center">
-                  <div style={{ fontSize: '2em' }}>{formatPercentage(outputStatistics.overhealingDone / (outputStatistics.healingDone + outputStatistics.overhealingDone))}%</div>
-                  <dfn data-tip="This includes all healing the occured while the buff was up, even if it was not triggered by spells cast inside the buff duration. Any delayed healing such as HOTs, Absorbs and Atonements will stop contributing to the healing done when the cooldown buff expires, so this value is lower for any specs with such abilities.">overhealing</dfn>
-                </div>*/}
+                <div className="col-md-2 text-center">
+                  <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone / (end - start) * 1000)} DPS</div>
+                  DPS
+                </div>
               </div>
             )
           }             

--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -125,7 +125,6 @@ class Cooldown extends React.Component {
       resourceStatistics = cooldown.events.filter(event => event.type === 'cast').reduce((mana, event) => mana + (event.manaCost || 0), 0);
     }
     
-    
     const start = cooldown.start;
     const end = cooldown.end || fightEnd;
 

--- a/src/Main/CooldownOverview.js
+++ b/src/Main/CooldownOverview.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import Cooldown from './Cooldown';
 
-const CooldownOverview = ({ fightStart, fightEnd, cooldowns, showHealingDone }) => (
+const CooldownOverview = ({ fightStart, fightEnd, cooldowns, showOutputStatistics, showResourceStatistics }) => (
   <div style={{ marginTop: -10, marginBottom: -10 }}>
     <ul className="list">
       {cooldowns.map((cooldown) => (
         <li key={`${cooldown.ability.id}-${cooldown.start}`} className="item clearfix" style={{ padding: '1em' }}>
-          <Cooldown cooldown={cooldown} fightStart={fightStart} fightEnd={fightEnd} showHealingDone={showHealingDone} />
+          <Cooldown cooldown={cooldown} fightStart={fightStart} fightEnd={fightEnd} showOutputStatistics={showOutputStatistics} showResourceStatistics={showResourceStatistics} />
         </li>
       ))}
     </ul>
@@ -16,12 +16,14 @@ const CooldownOverview = ({ fightStart, fightEnd, cooldowns, showHealingDone }) 
 CooldownOverview.propTypes = {
   fightStart: React.PropTypes.number.isRequired,
   fightEnd: React.PropTypes.number.isRequired,
-  showHealingDone: React.PropTypes.bool,
+  showOutputStatistics: React.PropTypes.bool,
+  showResourceStatistics: React.PropTypes.bool,
   cooldowns: React.PropTypes.arrayOf(React.PropTypes.shape({
     ability: React.PropTypes.shape({
       id: React.PropTypes.number.isRequired,
       name: React.PropTypes.string.isRequired,
       icon: React.PropTypes.string.isRequired,
+      cooldownType: React.PropTypes.string.isRequired
     }),
     start: React.PropTypes.number.isRequired,
     end: React.PropTypes.number,

--- a/src/Parser/Core/Modules/CooldownTracker.js
+++ b/src/Parser/Core/Modules/CooldownTracker.js
@@ -63,6 +63,11 @@ class CooldownTracker extends Module {
       cooldown.events.push(event);
     });
   }
+  on_byPlayer_damage(event) {
+    this.activeCooldowns.forEach((cooldown) => {
+      cooldown.events.push(event);
+    });
+  }
 }
 
 export default CooldownTracker;

--- a/src/Parser/HolyPaladin/CombatLogParser.js
+++ b/src/Parser/HolyPaladin/CombatLogParser.js
@@ -696,7 +696,8 @@ class CombatLogParser extends MainCombatLogParser {
             fightStart={this.fight.start_time}
             fightEnd={this.fight.end_time}
             cooldowns={this.modules.cooldownTracker.cooldowns}
-            showHealingDone
+            showOutputStatistics
+            showResourceStatistics
           />
         ),
       },

--- a/src/Parser/RestorationShaman/CombatLogParser.js
+++ b/src/Parser/RestorationShaman/CombatLogParser.js
@@ -506,7 +506,7 @@ class CombatLogParser extends MainCombatLogParser {
             fightStart={this.fight.start_time}
             fightEnd={this.fight.end_time}
             cooldowns={this.modules.cooldownTracker.cooldowns}
-            showHealingDone
+            showOutputStatistics
           />
         ),
       },

--- a/src/common/SPELLS_PALADIN.js
+++ b/src/common/SPELLS_PALADIN.js
@@ -107,6 +107,7 @@ export default {
     id: 31821,
     name: 'Aura Mastery',
     icon: 'spell_holy_auramastery',
+    cooldownType: 'HEALING'
   },
   AURA_OF_MERCY_HEAL: {
     id: 210291,
@@ -132,6 +133,7 @@ export default {
     id: 31842,
     name: 'Avenging Wrath',
     icon: 'spell_holy_avenginewrath',
+    cooldownType: 'HEALING'
   },
   BEACON_OF_LIGHT_BUFF: {
     id: 53563,
@@ -292,6 +294,7 @@ export default {
     id: 105809,
     name: 'Holy Avenger',
     icon: 'ability_paladin_holyavenger',
+    cooldownType: 'HEALING',
     description: '<a href="http://www.wowhead.com/spell=105809" target="_blank">Holy Avenger</a> provides a lot of on-demand healing. The downside to Holy Avenger is that is requires fairly heavy mana usage to be effective. This tier is mostly preference.',
   },
   HOLY_PRISM_TALENT: {

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -64,6 +64,7 @@ export default {
     id: 108281,
     name: 'Ancestral Guidance',
     icon: 'ability_shaman_ancestralguidance',
+    cooldownType: 'HEALING',
     description: 'The default choice in this tier. Can generate incredible throughput, especially when combined with <a href="http://www.wowhead.com/spell="157153" target="_blank">Cloudburst Totem</a> and/or <a href="http://www.wowhead.com/spell=114052" target="_blank">Ascendance</a>.',
   },
   ANCESTRAL_GUIDANCE_HEAL: {
@@ -75,6 +76,7 @@ export default {
     id: 114052,
     name: 'Ascendance',
     icon: 'spell_fire_elementaldevastation',
+    cooldownType: 'HEALING',
     description: 'Should almost always be combined with <a href="http://www.wowhead.com/spell=157153" target="_blank">Cloudburst Totem</a>. Provides you with an additional healing cooldown, or when combined with <a href="http://www.wowhead.com/spell=108281" target="_blank">Ancestral Guidance</a> makes for what is probably the strongest healing cooldown in the game. Does require proper planning to get value.'
   },
   ASCENDANCE_HEAL: {


### PR DESCRIPTION
Spells that are tracked in a CooldownTracker module need to have an additional property: cooldownType . This value can be either 'DAMAGE' or 'HEALING' depending on the statistic that you want to track during this cooldown. This way we can track any statistic for any spell.

I've changed some of the variable names to be Healing/Damage agnostic.
e.g. the showHealing boolean for the CooldownTracker is now: showOutputStatistics.
And an extra boolean has been added(showResourceStatistic) to show/hide the mana usage statistic during the cooldown duration.

I've taken the liberty of updating the two classes that used _showHealing_ on the cooldowns, which was RestoShaman and HolyPaladin, both work as before.