### PR TITLE
Add basic Elemental Shaman support

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+03-06-2017 - Added basic <span class="Shaman">Elemental Shaman</span> support by <b>@fasib</b>
 02-06-2017 - Mistweaver Monk: Enabled Dancing Mists tracking.  Healing provided by Dancing Mists procs now show in analysis. (by anomoly)
 01-06-2017 - Mistweaver Monk: Include healing from Chi-Ji talent into overall healing totals for monk. (by anomoly)
 01-06-2017 - Mistweaver Monk: Essence Font Tracking Implemented including tagets hit and HOT buffs utilized.  Readme updates for all modules and cast efficiency targets. (by anomoly)

--- a/src/Main/App.css
+++ b/src/Main/App.css
@@ -493,6 +493,45 @@ table.data-table .performance-bar {
 .kill { color: #1d9c07 !important }
 .wipe { color: #fb6d35 !important }
 
+.stat-health{color:#27cc4e !important}
+.stat-stamina{color:#ff8b2d !important}
+.stat-energy{color:#cb9501 !important}
+.stat-focus{color:#d45719 !important}
+.stat-fury{color:#8400ff !important}
+.stat-insanity{color:#60f !important}
+.stat-maelstrom{color:#008fff !important}
+.stat-mana{color:#1c8aff !important}
+.stat-pain{color:#d45719 !important}
+.stat-rage{color:#ab0000 !important}
+.stat-runicpower{color:#00bcde !important}
+.stat-agility{color:#ffd955 !important}
+.stat-intellect{color:#d26cd1 !important}
+.stat-strength{color:#f33232 !important}
+.stat-criticalstrike{color:#e01c1c !important}
+.stat-haste{color:#0ed59b !important}
+.stat-mastery{color:#9256ff !important}
+.stat-versatility{color:#bfbfbf !important}
+
+.stat-health-bg{background-color:#27cc4e !important}
+.stat-stamina-bg{background-color:#ff8b2d !important}
+.stat-energy-bg{background-color:#cb9501 !important}
+.stat-focus-bg{background-color:#d45719 !important}
+.stat-fury-bg{background-color:#8400ff !important}
+.stat-insanity-bg{background-color:#60f !important}
+.stat-maelstrom-bg{background-color:#008fff !important}
+.stat-mana-bg{background-color:#1c8aff !important}
+.stat-pain-bg{background-color:#d45719 !important}
+.stat-rage-bg{background-color:#ab0000 !important}
+.stat-runicpower-bg{background-color:#00bcde !important}
+.stat-agility-bg{background-color:#ffd955 !important}
+.stat-intellect-bg{background-color:#d26cd1 !important}
+.stat-strength-bg{background-color:#f33232 !important}
+.stat-criticalstrike-bg{background-color:#e01c1c !important}
+.stat-haste-bg{background-color:#0ed59b !important}
+.stat-mastery-bg{background-color:#9256ff !important}
+.stat-versatility-bg{background-color:#bfbfbf !important}
+
+
 .minor-issue-toggle {
   margin: -2px 0;
 }

--- a/src/Main/CastEfficiency.js
+++ b/src/Main/CastEfficiency.js
@@ -66,10 +66,13 @@ const CastEfficiency = ({ categories, abilities }) => {
 CastEfficiency.propTypes = {
   abilities: React.PropTypes.arrayOf(React.PropTypes.shape({
     ability: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      spellId: React.PropTypes.number.isRequired,
-      icon: React.PropTypes.string.isRequired,
-    }),
+      name: React.PropTypes.string,
+      category: React.PropTypes.string.isRequired,
+      spell: React.PropTypes.shape({
+        id: React.PropTypes.number.isRequired,
+        name: React.PropTypes.string.isRequired
+      }).isRequired
+    }).isRequired,
     cpm: React.PropTypes.number.isRequired,
     maxCpm: React.PropTypes.number,
     casts: React.PropTypes.number.isRequired,

--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -56,12 +56,12 @@ class Cooldown extends React.Component {
 
   handleExpandClick() {
     this.setState({
-      expanded: true,
+      expanded: !this.state.expanded,
     });
   }
   handleShowHealsClick() {
     this.setState({
-      showHeals: true,
+      showHeals: !this.state.showHeals,
     });
   }
 
@@ -165,7 +165,8 @@ class Cooldown extends React.Component {
                     </div>
                   </div>
                 ))}
-                <a href="javascript:" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>Even more</a>
+                <a href="javascript:" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>Even more</a>{' | '}
+                <a href="javascript:" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>Show less</a>
               </div>
             )}
             {this.state.expanded && this.state.showHeals && (
@@ -186,6 +187,8 @@ class Cooldown extends React.Component {
                     </div>
                   </div>
                 ))}
+                <a href="javascript:" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>Show less</a> {' | '}
+                <a href="javascript:" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>Show simple</a>
               </div>
             )}
           </div>

--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -211,11 +211,7 @@ class Cooldown extends React.Component {
               <div>
                 <div className="col-md-2 text-center">
                   <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone)}</div>
-                  <dfn data-tip="This number represents the total amount of damage done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">Damage Done</dfn>
-                </div>
-                <div className="col-md-2 text-center">
-                  <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone / (end - start) * 1000)}</div>
-                  <dfn data-tip="This number represents the total amount of DPS done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">DPS Done</dfn>
+                  <dfn data-tip="This number represents the total amount of damage done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">damage ({formatNumber(outputStatistics.damageDone / (end - start) * 1000)} DPS)</dfn>
                 </div>
               </div>
             )

--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -211,8 +211,8 @@ class Cooldown extends React.Component {
                   <dfn data-tip="This number represents the total amount of damage done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">Damage Done</dfn>
                 </div>
                 <div className="col-md-2 text-center">
-                  <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone / (end - start) * 1000)} DPS</div>
-                  DPS
+                  <div style={{ fontSize: '2em' }}>{formatNumber(outputStatistics.damageDone / (end - start) * 1000)}</div>
+                  <dfn data-tip="This number represents the total amount of DPS done during the duration of this cooldown, any damage done by DOTs after the effect of this cooldown has exprired will not be included in this statistic.">DPS Done</dfn>
                 </div>
               </div>
             )

--- a/src/Parser/AVAILABLE_CONFIGS.js
+++ b/src/Parser/AVAILABLE_CONFIGS.js
@@ -1,6 +1,7 @@
 import HolyPaladin from './HolyPaladin/CONFIG';
 import DisciplinePriest from './DisciplinePriest/CONFIG';
 import RestoDruid from './RestoDruid/CONFIG';
+import ElementalShaman from './ElementalShaman/CONFIG';
 import RestorationShaman from './RestorationShaman/CONFIG';
 import MistweaverMonk from './MistweaverMonk/CONFIG';
 
@@ -11,4 +12,5 @@ export default [
   RestoDruid,
   MistweaverMonk,
   RestorationShaman,
+  ElementalShaman
 ];

--- a/src/Parser/Core/Modules/AbilityTracker.js
+++ b/src/Parser/Core/Modules/AbilityTracker.js
@@ -79,7 +79,21 @@ class HealingTracker extends AbilityTracker {
   }
 }
 class DamageTracker extends HealingTracker {
-  // TODO: Implement
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    const cast = this.getAbility(spellId, event.ability);
+
+    cast.damangeHits = (cast.damangeHits || 0) + 1;
+    cast.damangeEffective = (cast.damangeEffective || 0) + (event.amount || 0);
+    cast.damangeAbsorbed = (cast.damangeAbsorbed || 0) + (event.absorbed || 0); // Not sure
+
+    const isCrit = event.hitType === HIT_TYPES.CRIT;
+    if (isCrit) {
+      cast.damangeCriticalHits = (cast.damangeCriticalHits || 0) + 1;
+      cast.damangeCriticalEffective = (cast.damangeCriticalEffective || 0) + (event.amount || 0);
+      cast.damangeCriticalAbsorbed = (cast.damangeCriticalAbsorbed || 0) + (event.absorbed || 0); // Not sure
+    }
+  }
 }
 
 export default DamageTracker;

--- a/src/Parser/Core/Modules/CooldownTracker.js
+++ b/src/Parser/Core/Modules/CooldownTracker.js
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 
 import Module from 'Parser/Core/Module';
 
-const debug = true;
+const debug = false;
 
 class CooldownTracker extends Module {
   static cooldownSpells = [

--- a/src/Parser/Core/Modules/Initialize.js
+++ b/src/Parser/Core/Modules/Initialize.js
@@ -1,6 +1,6 @@
 import Module from 'Parser/Core/Module';
 
-const debug = true;
+const debug = false;
 const TIMEOUT = 100;
 
 class Initialize extends Module {

--- a/src/Parser/ElementalShaman/CONFIG.js
+++ b/src/Parser/ElementalShaman/CONFIG.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import SPECS from 'common/SPECS';
+
+import CombatLogParser from './CombatLogParser';
+
+export default {
+  spec: SPECS.ELEMENTAL_SHAMAN,
+  parser: CombatLogParser,
+  maintainer: '@fasib',
+  footer: (
+    <div>
+      Based on Guides from <a href='https://www.stormearthandlava.com/'>Storm Earth and Lava</a>.<br />
+      Questions about Elementals? Visit <a href='http://www.discord.me/earthshrine'>Earthshrine</a> Discord.<br />
+    </div>
+  ),
+};

--- a/src/Parser/ElementalShaman/CPM_ABILITIES.js
+++ b/src/Parser/ElementalShaman/CPM_ABILITIES.js
@@ -1,0 +1,76 @@
+import SPELLS from 'common/SPELLS';
+
+export const SPELL_CATEGORY = {
+  ROTATIONAL: 'Spell',
+  ROTATIONAL_AOE: 'Spell (AOE)',
+  DOTS: 'Dot',
+  COOLDOWNS: 'Cooldown',
+};
+
+const CPM_ABILITIES = [
+  {
+    spell: SPELLS.LAVA_BURST,
+    charges: 2,
+    category: SPELL_CATEGORY.ROTATIONAL,
+    getCooldown: haste => null // haste => 8 / (1 + haste)
+    // TODO: Add Cooldown with stacks and Lava Surge procs
+  },
+  {
+    spell: SPELLS.LIGHTNING_BOLT,
+    category: SPELL_CATEGORY.ROTATIONAL,
+    getCooldown: haste => null // 1.5 / (1 + haste)
+  },
+  {
+    spell: SPELLS.LIQUID_MAGMA_TOTEM,
+    category: SPELL_CATEGORY.ROTATIONAL_AOE,
+    isActive: combatant => combatant.hasTalent(SPELLS.LIQUID_MAGMA_TOTEM.id),
+    getCooldown: haste => null
+  },
+  {
+    spell: SPELLS.CHAIN_LIGHTNING,
+    category: SPELL_CATEGORY.ROTATIONAL_AOE,
+    getCooldown: haste => null // 2 / (1 + haste)
+  },
+  {
+    spell: SPELLS.EARTHQUAKE,
+    category: SPELL_CATEGORY.ROTATIONAL_AOE,
+    getCooldown: haste => null
+  },
+  {
+    spell: SPELLS.ELEMENTAL_BLAST,
+    category: SPELL_CATEGORY.ROTATIONAL,
+    isActive: combatant => combatant.hasTalent(SPELLS.ELEMENTAL_BLAST.id),
+    getCooldown: haste => 12,
+    recommendedCastEfficiency: 0.6
+  },
+  {
+    spell: SPELLS.ASCENDANCE,
+    category: SPELL_CATEGORY.COOLDOWNS,
+    getCooldown: haste => 180,
+    isActive: combatant => combatant.hasTalent(SPELLS.ASCENDANCE.id),
+    recommendedCastEfficiency: 1.0
+  },
+  {
+    spell: SPELLS.STORMKEEPER,
+    category: SPELL_CATEGORY.COOLDOWNS,
+    getCooldown: haste => 60
+  },
+  {
+    spell: SPELLS.FIRE_ELEMENTAL,
+    category: SPELL_CATEGORY.COOLDOWNS,
+    getCooldown: haste => 60 * 5, // TODO: Add Elementalist -> Lava Burst cast ^= -2 sec cd
+    recommendedCastEfficiency: 1.0
+  },
+  {
+    spell: SPELLS.FLAME_SHOCK,
+    category: SPELL_CATEGORY.DOTS,
+    getCooldown: haste => null
+  },
+  {
+    spell: SPELLS.FROST_SHOCK,
+    category: SPELL_CATEGORY.DOTS,
+    getCooldown: haste => null
+  }
+];
+
+export default CPM_ABILITIES;

--- a/src/Parser/ElementalShaman/CombatLogParser.js
+++ b/src/Parser/ElementalShaman/CombatLogParser.js
@@ -206,11 +206,7 @@ class CombatLogParser extends MainCombatLogParser {
             }
           </span>
         )}
-        label={(
-          <dfn data-tip={`${formatPercentage(overloadLavaBurst.damangeHits / lavaBurst.casts )}% and ${formatPercentage(overloadLightningBolt.damangeHits / lightningBolt.casts)}% and ${formatPercentage(overloadElementalBlast.damangeHits / elementalBlast.casts )}%`}>
-            Overload procs
-          </dfn>
-        )}
+        label={'Overload procs'}
       />,
       <StatisticBox
         icon={<SpellIcon id={SPELLS.ELEMENTAL_BLAST.id} />}

--- a/src/Parser/ElementalShaman/CombatLogParser.js
+++ b/src/Parser/ElementalShaman/CombatLogParser.js
@@ -1,0 +1,293 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import Icon from 'common/Icon';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import ItemLink from 'common/ItemLink';
+import ItemIcon from 'common/ItemIcon';
+
+import StatisticBox from 'Main/StatisticBox';
+import SuggestionsTab from 'Main/SuggestionsTab';
+import TalentsTab from 'Main/TalentsTab';
+import CastEfficiencyTab from 'Main/CastEfficiencyTab';
+import CooldownsTab from 'Main/CooldownsTab';
+
+import MainCombatLogParser from 'Parser/Core/CombatLogParser';
+import ParseResults from 'Parser/Core/ParseResults';
+import getCastEfficiency from 'Parser/Core/getCastEfficiency';
+import ISSUE_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
+
+import ManaTab from './Modules/Main/MaelstromTab';
+
+import CooldownTracker from './Modules/Features/CooldownTracker';
+import ProcTracker from './Modules/Features/ProcTracker';
+import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
+
+import './Modules/Main/main.css';
+
+import CPM_ABILITIES, { SPELL_CATEGORY } from './CPM_ABILITIES';
+
+function formatThousands(number) {
+  return (Math.round(number || 0) + '').replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
+}
+
+function formatNumber(number) {
+  if (number > 1000000) {
+    return `${(number / 1000000).toFixed(2)}m`;
+  }
+  if (number > 10000) {
+    return `${Math.round(number / 1000)}k`;
+  }
+  return formatThousands(number);
+}
+
+function getIssueImportance(value, regular, major, higherIsWorse = false) {
+  if (higherIsWorse ? value > major : value < major) {
+    return ISSUE_IMPORTANCE.MAJOR;
+  }
+  if (higherIsWorse ? value > regular : value < regular) {
+    return ISSUE_IMPORTANCE.REGULAR;
+  }
+  return ISSUE_IMPORTANCE.MINOR;
+}
+function formatPercentage(percentage) {
+  return (Math.round((percentage || 0) * 10000) / 100).toFixed(2);
+}
+
+class CombatLogParser extends MainCombatLogParser {
+  static specModules = {
+    // Features
+    alwaysBeCasting: AlwaysBeCasting,
+    cooldownTracker: CooldownTracker,
+    procTracker: ProcTracker,
+
+    // Legendaries:
+  };
+
+  generateResults() {
+    const results = new ParseResults();
+    
+    const hasElementalBlast = this.selectedCombatant.hasTalent(SPELLS.ELEMENTAL_BLAST_TALENT.id);
+    const hasEchosElements = this.selectedCombatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id);
+    const hasAscendance = this.selectedCombatant.hasTalent(SPELLS.ASCENDANCE_ELEMENTAL_TALENT.id);
+    // const hasLightningRod = this.selectedCombatant.hasTalent(SPELLS.LIGHTNING_ROD.id);
+    const hasIcefury = this.selectedCombatant.hasTalent(SPELLS.ICEFURY_TALENT.id);
+    
+    const abilityTracker = this.modules.abilityTracker;
+    const getAbility = spellId => abilityTracker.getAbility(spellId);
+
+    const lavaBurst = getAbility(SPELLS.LAVA_BURST.id);
+    const lightningBolt = getAbility(SPELLS.LIGHTNING_BOLT.id);
+    const elementalBlast = getAbility(SPELLS.ELEMENTAL_BLAST.id);
+    const overloadLavaBurst = getAbility(SPELLS.LAVA_BURST_OVERLOAD.id);
+    const overloadLightningBolt = getAbility(SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id);
+    const overloadElementalBlast = getAbility(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id);
+    const overloadChainLightning = getAbility(SPELLS.CHAIN_LIGHTNING_OVERLOAD.id);
+    const overloadIcefury = hasIcefury && getAbility(SPELLS.ICEFURY_OVERLOAD.id);
+
+    const fightDuration = this.fightDuration;
+
+    const elementalBlastHasteUptime = this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_BLAST_HASTE.id) / this.fightDuration;
+    const elementalBlastCritUptime = this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_BLAST_CRIT.id) / this.fightDuration;
+    const elementalBlastMasteryUptime = this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_BLAST_MASTERY.id) / this.fightDuration;
+
+    const elementalBlastUptime = (elementalBlastHasteUptime + elementalBlastCritUptime + elementalBlastMasteryUptime);
+    const flameShockUptime = this.selectedCombatant.getBuffUptime(SPELLS.FLAME_SHOCK.id) / this.fightDuration;
+
+    const nonDpsTimePercentage = this.modules.alwaysBeCasting.totalDamagingTimeWasted / fightDuration;
+    const deadTimePercentage = this.modules.alwaysBeCasting.totalTimeWasted / fightDuration;
+
+    if (nonDpsTimePercentage > 0.3) {
+      results.addIssue({
+        issue: `[NYI] Your non DPS time can be improved. Try to cast damaging spells more regularly (${Math.round(nonDpsTimePercentage * 100)}% non DPS time).`,
+        icon: 'petbattle_health-down',
+        importance: getIssueImportance(nonDpsTimePercentage, 0.4, 0.45, true),
+      });
+    }
+    if (deadTimePercentage > 0.2) {
+      results.addIssue({
+        issue: `Your dead GCD time can be improved. (${Math.round(deadTimePercentage * 100)}% dead GCD time).`,
+        icon: 'spell_mage_altertime',
+        importance: getIssueImportance(deadTimePercentage, 0.35, 0.4, true),
+      });
+    }
+
+    const castEfficiencyCategories = SPELL_CATEGORY;
+    const castEfficiency = getCastEfficiency(CPM_ABILITIES, this);
+    castEfficiency.forEach((cpm) => {
+      if (cpm.canBeImproved && !cpm.ability.noSuggestion) {
+        results.addIssue({
+          issue: <span>Try to cast <SpellLink id={cpm.ability.spell.id} /> more often ({cpm.casts}/{cpm.maxCasts} casts: {Math.round(cpm.castEfficiency * 100)}% cast efficiency). {cpm.ability.extraSuggestion || ''}</span>,
+          icon: cpm.ability.spell.icon,
+          importance: cpm.ability.importance || getIssueImportance(cpm.castEfficiency, cpm.recommendedCastEfficiency - 0.05, cpm.recommendedCastEfficiency - 0.15),
+        });
+      }
+    });
+
+    results.statistics = [
+      <StatisticBox
+        icon={ <Icon icon="class_shaman" alt="Dead GCD time" /> }
+        value={formatThousands(this.totalDamage)}
+        label={(
+          <dfn data-tip="Without Fire Elemental Damage.">
+            Damage done
+          </dfn>
+        )}
+      />,
+      <StatisticBox
+        icon={<Icon icon="spell_mage_altertime" alt="Dead GCD time" />}
+        value={`${formatPercentage(deadTimePercentage)} %`}
+        label={(
+          <dfn data-tip="Dead GCD time is available casting time not used. This can be caused by latency, cast interrupting, not casting anything (e.g. due to movement/stunned), etc.">
+            Dead GCD time
+          </dfn>
+        )}
+      />,
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.ELEMENTAL_MASTERY.id} />}
+        value={(
+          <span className='flexJustify'>
+            <span>
+              <SpellIcon
+                id={SPELLS.LAVA_BURST_OVERLOAD.id}
+                style={{
+                  height: '1.3em',
+                  marginTop: '-.1em',
+                }}
+              />
+              {overloadLavaBurst.damangeHits}{' '}
+            </span>
+            {' '}
+            <span>
+              <SpellIcon
+                id={SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id}
+                style={{
+                  height: '1.3em',
+                  marginTop: '-.1em',
+                }}
+              />
+              {overloadLightningBolt.damangeHits}{' '}
+            </span>
+            {' '}
+            <span>
+              <SpellIcon
+                id={SPELLS.ELEMENTAL_BLAST_OVERLOAD.id}
+                style={{
+                  height: '1.3em',
+                  marginTop: '-.1em',
+                }}
+              />
+              {overloadElementalBlast.damangeHits}{' '}
+            </span>
+            {' '}
+            <span className="hideWider1200">
+              <SpellIcon
+                id={SPELLS.CHAIN_LIGHTNING_OVERLOAD.id}
+                style={{
+                  height: '1.3em',
+                  marginTop: '-.1em',
+                }}
+              />
+              {overloadChainLightning.damangeHits}{' '}
+            </span>
+            { hasIcefury &&
+              <span className="hideWider1200">
+                <SpellIcon
+                  id={SPELLS.ICEFURY_OVERLOAD.id}
+                  style={{
+                    height: '1.3em',
+                    marginTop: '-.1em',
+                  }}
+                />
+                {overloadIcefury ? overloadIcefury.damangeHits : '-' }{' '}
+              </span>
+            }
+          </span>
+        )}
+        label={(
+          <dfn data-tip={`${formatPercentage(overloadLavaBurst.damangeHits / lavaBurst.casts )}% and ${formatPercentage(overloadLightningBolt.damangeHits / lightningBolt.casts)}% and ${formatPercentage(overloadElementalBlast.damangeHits / elementalBlast.casts )}%`}>
+            Overload procs
+          </dfn>
+        )}
+      />,
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.ELEMENTAL_BLAST.id} />}
+        value={`${formatPercentage(elementalBlastUptime)} %`}
+        label={(
+          <dfn data-tip={`With <b class="stat-mastery">${formatPercentage(elementalBlastMasteryUptime)}% Mastery</b>, <b class="stat-criticalstrike">${formatPercentage(elementalBlastCritUptime)}% Crit</b>, <b  class="stat-haste">${formatPercentage(elementalBlastHasteUptime)}% Haste</b> Uptime`}>
+            Uptime
+          </dfn>
+        )}
+      />
+    ];
+
+    results.items = [/*TODO*/];
+
+    results.tabs = [
+      {
+        title: 'Suggestions',
+        url: 'suggestions',
+        render: () => (
+          <SuggestionsTab issues={results.issues} />
+        ),
+      },
+      {
+        title: 'Cast efficiency',
+        url: 'cast-efficiency',
+        render: () => (
+          <CastEfficiencyTab
+            categories={castEfficiencyCategories}
+            abilities={castEfficiency}
+          />
+        ),
+      },
+      {
+        title: 'Talents',
+        url: 'talents',
+        render: () => (
+          <TalentsTab combatant={this.selectedCombatant} />
+        ),
+      },
+      {
+        title: 'Cooldowns',
+        url: 'cooldowns',
+        render: () => (
+          <CooldownsTab
+            fightStart={this.fight.start_time}
+            fightEnd={this.fight.end_time}
+            cooldowns={this.modules.cooldownTracker.cooldowns}
+          />
+        ),
+      },
+      {
+        title: 'Procs',
+        url: 'procs',
+        render: () => (
+          <CooldownsTab
+            fightStart={this.fight.start_time}
+            fightEnd={this.fight.end_time}
+            cooldowns={this.modules.procTracker.cooldowns}
+          />
+        ),
+      },
+      {
+        title: 'Maelstrom',
+        url: 'maelstrom',
+        render: () => (
+          <ManaTab
+            reportCode={this.report.code}
+            actorId={this.playerId}
+            start={this.fight.start_time}
+            end={this.fight.end_time}
+          />
+        ),
+      },
+    ];
+
+    return results;
+  }
+}
+
+export default CombatLogParser;

--- a/src/Parser/ElementalShaman/CombatLogParser.js
+++ b/src/Parser/ElementalShaman/CombatLogParser.js
@@ -78,9 +78,9 @@ class CombatLogParser extends MainCombatLogParser {
     const abilityTracker = this.modules.abilityTracker;
     const getAbility = spellId => abilityTracker.getAbility(spellId);
 
-    const lavaBurst = getAbility(SPELLS.LAVA_BURST.id);
-    const lightningBolt = getAbility(SPELLS.LIGHTNING_BOLT.id);
-    const elementalBlast = getAbility(SPELLS.ELEMENTAL_BLAST.id);
+    // const lavaBurst = getAbility(SPELLS.LAVA_BURST.id);
+    // const lightningBolt = getAbility(SPELLS.LIGHTNING_BOLT.id);
+    // const elementalBlast = getAbility(SPELLS.ELEMENTAL_BLAST.id);
     const overloadLavaBurst = getAbility(SPELLS.LAVA_BURST_OVERLOAD.id);
     const overloadLightningBolt = getAbility(SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id);
     const overloadElementalBlast = getAbility(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id);

--- a/src/Parser/ElementalShaman/CombatLogParser.js
+++ b/src/Parser/ElementalShaman/CombatLogParser.js
@@ -3,10 +3,10 @@ import React from 'react';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 import Icon from 'common/Icon';
-import ITEMS from 'common/ITEMS';
+// import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import ItemLink from 'common/ItemLink';
-import ItemIcon from 'common/ItemIcon';
+// import ItemLink from 'common/ItemLink';
+// import ItemIcon from 'common/ItemIcon';
 
 import StatisticBox from 'Main/StatisticBox';
 import SuggestionsTab from 'Main/SuggestionsTab';
@@ -69,9 +69,9 @@ class CombatLogParser extends MainCombatLogParser {
   generateResults() {
     const results = new ParseResults();
     
-    const hasElementalBlast = this.selectedCombatant.hasTalent(SPELLS.ELEMENTAL_BLAST_TALENT.id);
-    const hasEchosElements = this.selectedCombatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id);
-    const hasAscendance = this.selectedCombatant.hasTalent(SPELLS.ASCENDANCE_ELEMENTAL_TALENT.id);
+    // const hasElementalBlast = this.selectedCombatant.hasTalent(SPELLS.ELEMENTAL_BLAST_TALENT.id);
+    // const hasEchosElements = this.selectedCombatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id);
+    // const hasAscendance = this.selectedCombatant.hasTalent(SPELLS.ASCENDANCE_ELEMENTAL_TALENT.id);
     // const hasLightningRod = this.selectedCombatant.hasTalent(SPELLS.LIGHTNING_ROD.id);
     const hasIcefury = this.selectedCombatant.hasTalent(SPELLS.ICEFURY_TALENT.id);
     
@@ -94,7 +94,7 @@ class CombatLogParser extends MainCombatLogParser {
     const elementalBlastMasteryUptime = this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_BLAST_MASTERY.id) / this.fightDuration;
 
     const elementalBlastUptime = (elementalBlastHasteUptime + elementalBlastCritUptime + elementalBlastMasteryUptime);
-    const flameShockUptime = this.selectedCombatant.getBuffUptime(SPELLS.FLAME_SHOCK.id) / this.fightDuration;
+    // const flameShockUptime = this.selectedCombatant.getBuffUptime(SPELLS.FLAME_SHOCK.id) / this.fightDuration;
 
     const nonDpsTimePercentage = this.modules.alwaysBeCasting.totalDamagingTimeWasted / fightDuration;
     const deadTimePercentage = this.modules.alwaysBeCasting.totalTimeWasted / fightDuration;
@@ -129,7 +129,7 @@ class CombatLogParser extends MainCombatLogParser {
     results.statistics = [
       <StatisticBox
         icon={ <Icon icon="class_shaman" alt="Dead GCD time" /> }
-        value={formatThousands(this.totalDamage)}
+        value={formatNumber(this.totalDamage)}
         label={(
           <dfn data-tip="Without Fire Elemental Damage.">
             Damage done

--- a/src/Parser/ElementalShaman/CombatLogParser.js
+++ b/src/Parser/ElementalShaman/CombatLogParser.js
@@ -258,6 +258,7 @@ class CombatLogParser extends MainCombatLogParser {
             fightStart={this.fight.start_time}
             fightEnd={this.fight.end_time}
             cooldowns={this.modules.cooldownTracker.cooldowns}
+            showOutputStatistics
           />
         ),
       },
@@ -269,6 +270,7 @@ class CombatLogParser extends MainCombatLogParser {
             fightStart={this.fight.start_time}
             fightEnd={this.fight.end_time}
             cooldowns={this.modules.procTracker.cooldowns}
+            showOutputStatistics
           />
         ),
       },

--- a/src/Parser/ElementalShaman/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/ElementalShaman/Modules/Features/AlwaysBeCasting.js
@@ -1,0 +1,26 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
+
+class AlwaysBeCasting extends CoreAlwaysBeCasting {
+  static ABILITIES_ON_GCD = [
+    // Note: I need to add a few more instant cast procs with different ids
+    // Elemental:
+    SPELLS.FROST_SHOCK.id,
+    SPELLS.FLAME_SHOCK.id,
+    SPELLS.ELEMENTAL_BLAST.id,
+    SPELLS.LAVA_BURST.id,
+    SPELLS.EARTH_SHOCK.id,
+
+    SPELLS.LIGHTNING_BOLT.id,
+    SPELLS.CHAIN_LIGHTNING.id,
+    SPELLS.EARTHQUAKE.id,
+    SPELLS.LIQUID_MAGMA_TOTEM.id,
+
+    SPELLS.STORMKEEPER.id,
+    SPELLS.ASCENDANCE.id,
+    SPELLS.FIRE_ELEMENTAL.id,
+  ];
+}
+
+export default AlwaysBeCasting;

--- a/src/Parser/ElementalShaman/Modules/Features/CooldownTracker.js
+++ b/src/Parser/ElementalShaman/Modules/Features/CooldownTracker.js
@@ -6,8 +6,8 @@ class CooldownTracker extends CoreCooldownTracker {
   static cooldownSpells = [
     ...CooldownTracker.cooldownSpells,
     SPELLS.ASCENDANCE,
-    SPELLS.STORMKEEPER,
-    SPELLS.BERSERKING
+    SPELLS.STORMKEEPER
+    // SPELLS.BERSERKING // Could be healing or damagin type, so skipping
   ];
 }
 

--- a/src/Parser/ElementalShaman/Modules/Features/CooldownTracker.js
+++ b/src/Parser/ElementalShaman/Modules/Features/CooldownTracker.js
@@ -1,0 +1,14 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreCooldownTracker from 'Parser/Core/Modules/CooldownTracker';
+
+class CooldownTracker extends CoreCooldownTracker {
+  static cooldownSpells = [
+    ...CooldownTracker.cooldownSpells,
+    SPELLS.ASCENDANCE,
+    SPELLS.STORMKEEPER,
+    SPELLS.BERSERKING
+  ];
+}
+
+export default CooldownTracker;

--- a/src/Parser/ElementalShaman/Modules/Features/ProcTracker.js
+++ b/src/Parser/ElementalShaman/Modules/Features/ProcTracker.js
@@ -1,0 +1,13 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreCooldownTracker from 'Parser/Core/Modules/CooldownTracker';
+
+class ProcTracker extends CoreCooldownTracker {
+  static cooldownSpells = [
+    SPELLS.POWER_OF_THE_MAELSTROM,
+    SPELLS.ELEMENTAL_FOCUS,
+    SPELLS.LAVA_SURGE
+  ];
+}
+
+export default ProcTracker;

--- a/src/Parser/ElementalShaman/Modules/Main/CastEfficiency.js
+++ b/src/Parser/ElementalShaman/Modules/Main/CastEfficiency.js
@@ -1,0 +1,69 @@
+// Based on Main/CastEfficiency.js
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+
+const CastEfficiency = ({ categories, abilities }) => {
+  if (!abilities) {
+    return <div>Loading...</div>;
+  }
+  return (
+    <div style={{ marginTop: -10, marginBottom: -10 }}>
+      <table className="data-table" style={{ marginTop: 10, marginBottom: 10 }}>
+        {Object.keys(categories).map((key) => (
+          <tbody key={key}>
+            <tr>
+              <th>{categories[key]}</th>
+              <th className="text-center">Casts</th>
+              <th className="text-center">{key === 'spend' ? <dfn data-tip="Approxomatly.">Spend</dfn> : ''}</th>
+              <th className="text-center">{key === 'generated' ? <dfn data-tip="Approxomatly.">Generated</dfn> : ''}</th>
+              <th className="text-center"><dfn data-tip="Approxomatly.">Wasted</dfn></th>
+              <th></th>
+            </tr>
+            {abilities
+              .filter(item => item.ability.category === categories[key])
+            .map(({ ability, casts, spend, created, wasted, canBeImproved }) => {
+              const name = ability.name;
+              return (
+                <tr key={name}>
+                  <td style={{ width: '35%' }}>
+                    <SpellLink id={ability.spellId} style={{ color: '#fff' }}>
+                      <SpellIcon id={ability.spellId} noLink /> {name}
+                    </SpellLink>
+                  </td>
+                  <td className="text-center" style={{ minWidth: 80 }}>
+                    {casts}
+                  </td>
+                  <td className="text-center" style={{ minWidth: 80 }}>
+                    {spend ? spend : ''}
+                  </td>
+                  <td className="text-center" style={{ minWidth: 80 }}>
+                    {created ? created : ''}
+                  </td>
+                  <td className="text-center" style={{ minWidth: 80 }}>
+                    {wasted ? wasted : ''}
+                  </td>
+                  <td style={{ width: '25%', color: 'orange' }}>
+                    {canBeImproved && !ability.noCanBeImproved && 'Can be improved.'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        ))}
+      </table>
+    </div>
+  );
+};
+CastEfficiency.propTypes = {
+  abilities: React.PropTypes.arrayOf(React.PropTypes.shape({
+    ability: React.PropTypes.shape({
+      name: React.PropTypes.string.isRequired,
+      category: React.PropTypes.string.isRequired,
+      spellId: React.PropTypes.number.isRequired
+    }).isRequired,
+  })).isRequired,
+};
+
+export default CastEfficiency;

--- a/src/Parser/ElementalShaman/Modules/Main/Maelstrom.css
+++ b/src/Parser/ElementalShaman/Modules/Main/Maelstrom.css
@@ -1,0 +1,23 @@
+.ct-series.wasted .ct-bar, .ct-series.wasted .ct-line, .ct-series.wasted .ct-point, .ct-series.wasted .ct-slice-donut {
+  stroke: #ff6dd7;
+}
+.ct-series.wasted .ct-area, .ct-series.wasted .ct-slice-donut-solid, .ct-series.wasted .ct-slice-pie {
+  fill: #ff2ad7;
+  fill-opacity: 0.2;
+}
+.ct-legend .wasted:before {
+  background-color: #ff6dd7;
+  border-color: #ff6dd7;
+}
+
+.ct-series.maelstrom .ct-bar, .ct-series.maelstrom .ct-line, .ct-series.maelstrom .ct-point, .ct-series.maelstrom .ct-slice-donut {
+  stroke: #008fff;
+}
+.ct-series.maelstrom .ct-area, .ct-series.maelstrom .ct-slice-donut-solid, .ct-series.maelstrom .ct-slice-pie {
+  fill: #008fff;
+  fill-opacity: 0.2;
+}
+.ct-legend .maelstrom:before {
+  background-color: #008fff;
+  border-color: #008fff;
+}

--- a/src/Parser/ElementalShaman/Modules/Main/Maelstrom.js
+++ b/src/Parser/ElementalShaman/Modules/Main/Maelstrom.js
@@ -1,0 +1,296 @@
+// Based on Main/Mana.js
+
+import React from 'react';
+import ChartistGraph from 'react-chartist';
+import Chartist from 'chartist';
+import 'chartist-plugin-legend';
+
+import SPELLS from 'common/SPELLS'
+
+import CastEfficiency from './CastEfficiency';
+
+import specialEventIndicators from 'Main/Chartist/specialEventIndicators';
+// import tooltips from './Chartist/toolips';
+
+import WCL_API_KEY from 'Main/WCL_API_KEY';
+
+import 'Main/Mana.css';
+import './Maelstrom.css';
+
+const formatDuration = (duration) => {
+  const seconds = Math.floor(duration % 60);
+  return `${Math.floor(duration / 60)}:${seconds < 10 ? `0${seconds}` : seconds}`;
+};
+
+class Maelstrom extends React.PureComponent {
+  static propTypes = {
+    reportCode: React.PropTypes.string.isRequired,
+    actorId: React.PropTypes.number.isRequired,
+    start: React.PropTypes.number.isRequired,
+    end: React.PropTypes.number.isRequired,
+  };
+
+  constructor() {
+    super();
+    this.state = {
+      mana: null,
+      bossHealth: null,
+    };
+  }
+
+  componentWillMount() {
+    this.load(this.props.reportCode, this.props.actorId, this.props.start, this.props.end);
+  }
+  componentWillReceiveProps(newProps) {
+    if (newProps.reportCode !== this.props.reportCode || newProps.actorId !== this.props.actorId || newProps.start !== this.props.start || newProps.end !== this.props.end) {
+      this.load(newProps.reportCode, newProps.actorId, newProps.start, newProps.end);
+    }
+  }
+  load(reportCode, actorId, start, end) {
+    const manaPromise = fetch(`https://www.warcraftlogs.com/v1/report/tables/resources/${reportCode}?start=${start}&end=${end}&sourceid=${actorId}&abilityid=111&api_key=${WCL_API_KEY}`)
+      .then(response => response.json())
+      .then((json) => {
+        if (json.status === 400 || json.status === 401) {
+          throw json.error;
+        } else {
+          this.setState({
+            mana: json,
+          });
+        }
+      });
+
+    const bossHealthPromise = fetch(`https://www.warcraftlogs.com/v1/report/tables/resources/${reportCode}?start=${start}&end=${end}&sourceclass=Boss&hostility=1&abilityid=1000&api_key=${WCL_API_KEY}`)
+      .then(response => response.json())
+      .then((json) => {
+        if (json.status === 400 || json.status === 401) {
+          throw json.error;
+        } else {
+          this.setState({
+            bossHealth: json,
+          });
+        }
+      });
+
+    return Promise.all([ manaPromise, bossHealthPromise ]);
+  }
+
+  render() {
+    if (!this.state.mana || !this.state.bossHealth) {
+      return (
+        <div>
+          Loading...
+        </div>
+      );
+    }
+
+    const { start, end } = this.props;
+
+    const manaBySecond = {
+      0: 100,
+    };
+    this.state.mana.series[0].data.forEach((item) => {
+      const secIntoFight = Math.floor((item[0] - start) / 1000);
+      manaBySecond[secIntoFight] = item[1];
+    });
+    const bosses = [];
+    const deadBosses = [];
+    this.state.bossHealth.series.forEach((series) => {
+      const newSeries = {
+        ...series,
+        data: {},
+      };
+
+      series.data.forEach((item) => {
+        const secIntoFight = Math.floor((item[0] - start) / 1000);
+
+        if (deadBosses.indexOf(series.guid) === -1) {
+          const health = item[1];
+          newSeries.data[secIntoFight] = health;
+
+          if (health === 0) {
+            deadBosses.push(series.guid);
+          }
+        }
+      });
+      bosses.push(newSeries);
+    });
+    const deathsBySecond = {};
+    this.state.mana.deaths.forEach((death) => {
+      const secIntoFight = Math.floor((death.timestamp - start) / 1000);
+
+      if (death.targetIsFriendly) {
+        deathsBySecond[secIntoFight] = true;
+      }
+    });
+    
+    
+    let abilitiesAll = {}
+    let categories = {
+      'generated': 'Generated',
+      'spend': 'Spend',
+    }
+    let abilities = []
+
+    const overCapBySecond = {};
+    let lastOverCap;
+    let lastSecFight = start
+    this.state.mana.series[0].events.forEach((event) => {
+      const secIntoFight = Math.floor((event.timestamp - start) / 1000);
+      if (event.waste === 0 && lastOverCap) {
+        overCapBySecond[lastOverCap + 1] = 0;
+      }
+      overCapBySecond[secIntoFight] = event.waste;
+      if (event.waste > 0 ) {
+        lastOverCap = secIntoFight
+        //if (!overCapBySecond[secIntoFight - 1])
+        //  overCapBySecond[secIntoFight - 1] = 0;
+      }
+      if (event.type === 'cast') {
+        let spell = SPELLS[event.ability.guid]
+        if (!abilitiesAll[event.ability.guid + '_spend']) {
+          abilitiesAll[event.ability.guid + '_spend'] = {
+            ability: {
+              category: 'Spend',
+              name: spell.name || event.ability.name,
+              spellId: event.ability.guid,
+            },
+            spend: 0,
+            casts: 0,
+            created: 0,
+            wasted: 0
+          }
+        }
+        abilitiesAll[event.ability.guid + '_spend'].casts++
+        let lastMana = lastSecFight === secIntoFight ? manaBySecond[lastSecFight-1] : manaBySecond[lastSecFight]
+        let spendResource = spell.maelstrom ? spell.maelstrom : (spell.max_maelstrom < lastMana ? spell.max_maelstrom : lastMana)
+        abilitiesAll[event.ability.guid + '_spend'].spend += spendResource
+        abilitiesAll[event.ability.guid + '_spend'].wasted += spell.max_maelstrom ? spell.max_maelstrom - spendResource: 0
+      } else if (event.type === 'energize') {
+        if (!abilitiesAll[event.ability.guid + '_gen']) {
+          let spell = SPELLS[event.ability.guid]
+          abilitiesAll[event.ability.guid + '_gen'] = {
+            ability: {
+              category: 'Generated',
+              name: spell.name || event.ability.name,
+              spellId: event.ability.guid,
+            },
+            spend: 0,
+            casts: 0,
+            created: 0,
+            wasted: 0
+          }
+        }
+        abilitiesAll[event.ability.guid + '_gen'].casts++
+        abilitiesAll[event.ability.guid + '_gen'].created += event.resourceChange
+        abilitiesAll[event.ability.guid + '_gen'].wasted += event.waste
+      }
+      if (secIntoFight !== lastSecFight) {
+        lastSecFight = secIntoFight
+      }
+    });
+
+    abilities = Object.keys(abilitiesAll).map((key) => abilitiesAll[key])
+    abilities.sort((a,b) => {
+      if (a.created < b.created) {
+        return 1
+      } else if (a.created === b.created) {
+        return 0
+      }
+      return -1
+    })
+
+    const fightDurationSec = Math.ceil((end - start) / 1000);
+    const labels = [];
+    for (let i = 0; i <= fightDurationSec; i += 1) {
+      labels.push(i);
+
+      manaBySecond[i] = manaBySecond[i] !== undefined ? manaBySecond[i] : null;
+      overCapBySecond[i] = overCapBySecond[i] !== undefined ? overCapBySecond[i] : null;
+      bosses.forEach((series) => {
+        series.data[i] = series.data[i] !== undefined ? series.data[i] : null;
+      });
+      deathsBySecond[i] = deathsBySecond[i] !== undefined ? deathsBySecond[i] : undefined;
+    }
+
+    const chartData = {
+      labels: labels,
+      series: [
+        ...bosses.map((series, index) => ({
+          className: `boss-health boss-${index} boss-${series.guid}`,
+          name: `${series.name} Health`,
+          data: Object.keys(series.data).map(key => series.data[key]),
+        })),
+        {
+          className: 'maelstrom',
+          name: 'Maelstrom',
+          data: Object.keys(manaBySecond).map(key => manaBySecond[key]),
+        },
+        {
+          className: 'wasted',
+          name: 'Maelstrom wasted',
+          data: Object.keys(overCapBySecond).map(key => overCapBySecond[key]),
+        }
+      ],
+    };
+    let step = 0;
+
+    return (
+      <div>
+        <ChartistGraph
+          data={chartData}
+          options={{
+            low: 0,
+            high: 130,
+            showArea: true,
+            showPoint: false,
+            fullWidth: true,
+            height: '300px',
+            lineSmooth: Chartist.Interpolation.simple({
+              fillHoles: true,
+            }),
+            axisX: {
+              labelInterpolationFnc: function skipLabels(seconds) {
+                if (seconds < ((step - 1) * 30)) {
+                  step = 0;
+                }
+                if (step === 0 || seconds >= (step * 30)) {
+                  step += 1;
+                  return formatDuration(seconds);
+                }
+                return null;
+              },
+              offset: 20,
+            },
+            axisY: {
+              onlyInteger: true,
+              offset: 35,
+              labelInterpolationFnc: function skipLabels(percentage) {
+                return `${percentage}`;
+              },
+            },
+            plugins: [
+              Chartist.plugins.legend({
+                classNames: [
+                  ...bosses.map((series, index) => `boss-health boss-${index} boss-${series.guid}`),
+                  'maelstrom',
+                  'wasted'
+                ],
+              }),
+              specialEventIndicators({
+                series: ['death'],
+              }),
+              // tooltips(),
+            ],
+          }}
+          type="Line"
+        />
+        <CastEfficiency
+          abilities={abilities}
+          categories={categories}
+          />
+      </div>
+    );
+  }
+}
+
+export default Maelstrom;

--- a/src/Parser/ElementalShaman/Modules/Main/MaelstromTab.js
+++ b/src/Parser/ElementalShaman/Modules/Main/MaelstromTab.js
@@ -1,0 +1,19 @@
+// Based on Main/ManaTab.js
+import React from 'react';
+
+import Maelstrom from './Maelstrom';
+
+const MaelstromTab = ({ ...others }) => (
+  <div>
+    <div className="panel-heading">
+      <h2>Maelstrom</h2>
+    </div>
+    <div style={{ padding: '15px 22px' }}>
+      <Maelstrom
+        {...others}
+      />
+    </div>
+  </div>
+);
+
+export default MaelstromTab;

--- a/src/Parser/ElementalShaman/Modules/Main/main.css
+++ b/src/Parser/ElementalShaman/Modules/Main/main.css
@@ -1,0 +1,21 @@
+.flexJustify {
+  display: flex;
+  justify-content: space-between;
+}
+
+.inlineBlocks span {
+  display: inline-block;
+}
+
+@media (min-width: 768px) {
+  .flexJustify span {
+    margin-top: -0.5rem;
+    line-height: 1.2em;
+  }
+}
+
+@media (min-width: 1200px) {
+  .hideWider1200 {
+    display: none;
+  }
+}

--- a/src/Parser/ElementalShaman/Modules/ShamanCore/ElementalAbilityTracker.js
+++ b/src/Parser/ElementalShaman/Modules/ShamanCore/ElementalAbilityTracker.js
@@ -1,0 +1,17 @@
+// import SPELLS from 'common/SPELLS';
+
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+
+class ElementalAbilityTracker extends AbilityTracker {
+  on_byPlayer_cast(event) {
+    if (super.on_byPlayer_cast) {
+      super.on_byPlayer_cast(event);
+    }
+    const spellId = event.ability.guid;
+    const cast = this.getAbility(spellId, event.ability);
+    cast
+    // TODO: add debuff/buff infos
+  }
+}
+
+export default ElementalAbilityTracker;

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -4,6 +4,218 @@ export default {
     name: 'Astral Shift',
     icon: 'ability_shaman_astralshift',
   },
+  // Elemental Shaman
+  ELEMENTAL_MASTERY: {
+    id: 168534,
+    name: 'Elemental Overload',
+    icon: 'spell_nature_lightningoverload'
+  },
+  Resonance_Totem: {
+    id: 202192,
+    name: 'Resonance Totem',
+    icon: 'spell_nature_stoneskintotem'
+  },
+  EARTH_SHOCK: {
+    id: 8042,
+    name: 'Earth Shock',
+    icon: 'spell_nature_earthshock',
+    max_maelstrom: 125 // default without talent
+  },
+  LAVA_BURST: {
+    id: 51505,
+    name: 'Lava Burst',
+    icon: 'spell_shaman_lavaburst'
+  },
+  LAVA_BURST_OVERLOAD: {
+    id: 77451,
+    name: 'Lava Burst Overload',
+    icon: 'spell_shaman_lavaburst'
+  },
+  LIGHTNING_BOLT: {
+    id: 188196,
+    name: 'Lightning Bolt',
+    icon: 'spell_nature_lightning'
+  },
+  LIGHTNING_BOLT_INSTANT: {
+    id: 214815,
+    name: 'Lightning Bolt',
+    icon: 'spell_nature_lightning'
+  },
+  LIGHTNING_BOLT_OVERLOAD: {
+    id: 214816,
+    name: 'Lightning Bolt Overload',
+    icon: 'spell_nature_lightning'
+  },
+  LIGHTNING_BOLT_OVERLOAD_HIT: {
+    id: 45284,
+    name: 'Lightning Bolt Overload',
+    icon: 'spell_nature_lightning'
+  },
+  ELEMENTAL_BLAST: {
+    id: 117014,
+    name: 'Elemental Blast',
+    icon: 'shaman_talent_elementalblast'
+  },
+  ELEMENTAL_BLAST_OVERLOAD: {
+    id: 120588,
+    name: 'Elemental Blast',
+    icon: 'shaman_talent_elementalblast'
+  },
+  ELEMENTAL_BLAST_HASTE: {
+    id: 173183,
+    name: 'Elemental Blast: Haste',
+    icon: 'shaman_talent_elementalblast'
+  },
+  ELEMENTAL_BLAST_CRIT: {
+    id: 118522,
+    name: 'Elemental Blast: Critical Strike',
+    icon: 'shaman_talent_elementalblast'
+  },
+  ELEMENTAL_BLAST_MASTERY: {
+    id: 173184,
+    name: 'Elemental Blast: Mastery',
+    icon: 'shaman_talent_elementalblast'
+  },
+  CHAIN_LIGHTNING: {
+    id: 188443,
+    name: 'Chain Lightning',
+    icon: 'spell_nature_chainlightning'
+  },
+  CHAIN_LIGHTNING_INSTANT: {
+    id: 195897,
+    name: 'Chain Lightning',
+    icon: 'spell_nature_chainlightning'
+  },
+  CHAIN_LIGHTNING_OVERLOAD: {
+    id: 218558,
+    name: 'Chain Lightning Overload',
+    icon: 'spell_nature_chainlightning'
+  },
+  EARTHQUAKE: {
+    id: 61882,
+    name: 'Earthquake',
+    icon: 'spell_shaman_earthquake',
+    maelstrom: 50
+  },
+  LIQUID_MAGMA_TOTEM: {
+    id: 192222,
+    name: 'Liquid Magma Totem',
+    icon: 'spell_shaman_spewlava'
+  },
+  STORMKEEPER: {
+    id: 205495,
+    name: 'Stormkeeper',
+    icon: 'inv_hand_1h_artifactstormfist_d_01'
+  },
+  ASCENDANCE: {
+    id: 114050,
+    name: 'Ascendance',
+    icon: 'spell_fire_elementaldevastation'
+  },
+  FIRE_ELEMENTAL: {
+    id: 198067,
+    name: 'Fire Elemental',
+    icon: 'spell_fire_elemental_totem'
+  },
+  FLAME_SHOCK: {
+    id: 188389,
+    name: 'Flame Shock',
+    icon: 'spell_fire_flameshock',
+    max_maelstrom: 20
+  },
+  FROST_SHOCK: {
+    id: 196840,
+    name: 'Frost Shock',
+    icon: 'spell_frost_frostshock',
+    max_maelstrom: 20
+  },
+  ICEFURY_OVERLOAD: {
+    id: 219271,
+    name: 'Icefury Overload',
+    icon: 'spell_frost_iceshard'
+  },
+  // Elemental Shaman Talents
+  EARTHEN_RAGE_TALENT: {
+    id: '170374',
+    name: 'Earthen Rage',
+    icon: 'ability_earthen_pillar'
+  },
+  // 'GUST_OF_WIND_TALENT'
+  PATH_OF_FLAME_TALENT: {
+    id: '201909',
+    name: 'Path of Flame',
+    icon: 'spell_mage_flameorb'
+  },
+  TOTEM_MASTERY_TALENT: {
+    id: '210643',
+    name: 'Totem Mastery',
+    icon: 'spell_nature_wrathofair_totem'
+  },
+  // 'ANCESTRAL_GUIDANCE_TALENT'
+  AFTERSHOCK_TALENT: {
+    id: '210707',
+    name: 'Aftershock',
+    icon: 'spell_nature_stormreach'
+  },
+  AFTERSHOCK: {
+    id: '210712',
+    name: 'Aftershock',
+    icon: 'spell_nature_stormreach'
+  },
+  // 'WIND_RUSH_TOTEM_TALENT'
+  ANCESTRAL_SWIFTNESS_TALENT: {
+    id: '192087',
+    name: 'Ancestral Swiftness',
+    icon: 'spell_shaman_elementaloath'
+  },
+  ELEMENTAL_MASTERY_TALENT: {
+    id: '16166',
+    name: 'Elemental Mastery',
+    icon: 'spell_nature_wispheal'
+  },
+  PRIMAL_ELEMENTALIST_TALENT: {
+    id: '117013',
+    name: 'Primal Elementalist',
+    icon: 'shaman_talent_primalelementalist'
+  },
+  ELEMENTAL_FUSION_TALENT: {
+    id: '192235',
+    name: 'Elemental Fusion',
+    icon: 'spell_shaman_shockinglava'
+  },
+  ELEMENTAL_BLAST_TALENT: {
+    id: '117014',
+    name: 'Elemental Blast',
+    icon: 'shaman_talent_elementalblast'
+  },
+  STORM_ELEMENTAL_TALENT: {
+    id: '192249',
+    name: 'Storm Elemental',
+    icon: 'spell_shaman_measuredinsight'
+  },
+  LIQUID_MAGMA_TOTEM_TALENT: {
+    id: '192222',
+    name: 'Liquid Magma Totem',
+    icon: 'spell_shaman_spewlava'
+  },
+  // 'ECHO_OF_THE_ELEMENTS_TALENT'
+  ASCENDANCE_ELEMENTAL_TALENT: {
+    id: 114050,
+    name: 'Ascendance',
+    icon: 'spell_fire_elementaldevastation',
+  },
+  LIGHTNING_ROD: {
+    id: '210689',
+    name: 'Lightning Rod',
+    icon: 'inv_rod_enchantedcobalt'
+  },
+  ICEFURY_TALENT: {
+    id: '210714',
+    name: 'Icefury',
+    icon: 'spell_frost_iceshard'
+  },
+  // Enhancement Shaman
+  // TODO: add spells
   // Restoration Shaman
   CHAIN_HEAL: {
     id: 1064,
@@ -309,8 +521,5 @@ export default {
     id: 238143,
     name: 'Deep Waters',
     icon: 'inv_mace_1h_artifactazshara_d_02',
-  },
-
+  }
 }
-
-

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -110,12 +110,14 @@ export default {
   STORMKEEPER: {
     id: 205495,
     name: 'Stormkeeper',
-    icon: 'inv_hand_1h_artifactstormfist_d_01'
+    icon: 'inv_hand_1h_artifactstormfist_d_01',
+    cooldownType: 'DAMAGE'
   },
   ASCENDANCE: {
     id: 114050,
     name: 'Ascendance',
-    icon: 'spell_fire_elementaldevastation'
+    icon: 'spell_fire_elementaldevastation',
+    cooldownType: 'DAMAGE'
   },
   FIRE_ELEMENTAL: {
     id: 198067,
@@ -142,17 +144,20 @@ export default {
   POWER_OF_THE_MAELSTROM: {
     id: 191877,
     name: 'Power of the Maelstrom',
-    icon: 'spell_fire_masterofelements'
+    icon: 'spell_fire_masterofelements',
+    cooldownType: 'DAMAGE'
   },
   ELEMENTAL_FOCUS: {
     id: 16246,
     name: 'Elemental Focus',
-    icon: 'spell_shadow_manaburn'
+    icon: 'spell_shadow_manaburn',
+    cooldownType: 'DAMAGE'
   },
   LAVA_SURGE: {
     id: 77762,
     name: 'Lava Surge',
-    icon: 'spell_shaman_lavasurge'
+    icon: 'spell_shaman_lavasurge',
+    cooldownType: 'DAMAGE'
   },
   // Elemental Shaman Talents
   EARTHEN_RAGE_TALENT: {

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -87,6 +87,11 @@ export default {
     icon: 'spell_nature_chainlightning'
   },
   CHAIN_LIGHTNING_OVERLOAD: {
+    id: 45297,
+    name: 'Chain Lightning Overload',
+    icon: 'spell_nature_chainlightning'
+  },
+  CHAIN_LIGHTNING_OVERLOAD_UNLIMITED_RANGE: {
     id: 218558,
     name: 'Chain Lightning Overload',
     icon: 'spell_nature_chainlightning'
@@ -134,67 +139,82 @@ export default {
     name: 'Icefury Overload',
     icon: 'spell_frost_iceshard'
   },
+  POWER_OF_THE_MAELSTROM: {
+    id: 191877,
+    name: 'Power of the Maelstrom',
+    icon: 'spell_fire_masterofelements'
+  },
+  ELEMENTAL_FOCUS: {
+    id: 16246,
+    name: 'Elemental Focus',
+    icon: 'spell_shadow_manaburn'
+  },
+  LAVA_SURGE: {
+    id: 77762,
+    name: 'Lava Surge',
+    icon: 'spell_shaman_lavasurge'
+  },
   // Elemental Shaman Talents
   EARTHEN_RAGE_TALENT: {
-    id: '170374',
+    id: 170374,
     name: 'Earthen Rage',
     icon: 'ability_earthen_pillar'
   },
   // 'GUST_OF_WIND_TALENT'
   PATH_OF_FLAME_TALENT: {
-    id: '201909',
+    id: 201909,
     name: 'Path of Flame',
     icon: 'spell_mage_flameorb'
   },
   TOTEM_MASTERY_TALENT: {
-    id: '210643',
+    id: 210643,
     name: 'Totem Mastery',
     icon: 'spell_nature_wrathofair_totem'
   },
   // 'ANCESTRAL_GUIDANCE_TALENT'
   AFTERSHOCK_TALENT: {
-    id: '210707',
+    id: 210707,
     name: 'Aftershock',
     icon: 'spell_nature_stormreach'
   },
   AFTERSHOCK: {
-    id: '210712',
+    id: 210712,
     name: 'Aftershock',
     icon: 'spell_nature_stormreach'
   },
   // 'WIND_RUSH_TOTEM_TALENT'
   ANCESTRAL_SWIFTNESS_TALENT: {
-    id: '192087',
+    id: 192087,
     name: 'Ancestral Swiftness',
     icon: 'spell_shaman_elementaloath'
   },
   ELEMENTAL_MASTERY_TALENT: {
-    id: '16166',
+    id: 16166,
     name: 'Elemental Mastery',
     icon: 'spell_nature_wispheal'
   },
   PRIMAL_ELEMENTALIST_TALENT: {
-    id: '117013',
+    id: 117013,
     name: 'Primal Elementalist',
     icon: 'shaman_talent_primalelementalist'
   },
   ELEMENTAL_FUSION_TALENT: {
-    id: '192235',
+    id: 192235,
     name: 'Elemental Fusion',
     icon: 'spell_shaman_shockinglava'
   },
   ELEMENTAL_BLAST_TALENT: {
-    id: '117014',
+    id: 117014,
     name: 'Elemental Blast',
     icon: 'shaman_talent_elementalblast'
   },
   STORM_ELEMENTAL_TALENT: {
-    id: '192249',
+    id: 192249,
     name: 'Storm Elemental',
     icon: 'spell_shaman_measuredinsight'
   },
   LIQUID_MAGMA_TOTEM_TALENT: {
-    id: '192222',
+    id: 192222,
     name: 'Liquid Magma Totem',
     icon: 'spell_shaman_spewlava'
   },
@@ -205,12 +225,12 @@ export default {
     icon: 'spell_fire_elementaldevastation',
   },
   LIGHTNING_ROD: {
-    id: '210689',
+    id: 210689,
     name: 'Lightning Rod',
     icon: 'inv_rod_enchantedcobalt'
   },
   ICEFURY_TALENT: {
-    id: '210714',
+    id: 210714,
     name: 'Icefury',
     icon: 'spell_frost_iceshard'
   },


### PR DESCRIPTION
For #51 
I added besides the Basic Elemental support, some stat colors and the DamageTracker implementation.

All new components are saved inside the `ElementalShaman/Modules/Main` folder.

The `MaelstromTab` and `Maelstrom` components are based on the `Mana*` ones.
The custom `CastEfficiency` will be later renamed to `MaelstromEfficiency`.

Some Tooltips need some work and are not done yet.

WIP
![cast efficiency](https://vgy.me/90vTpA.jpg)
Without Talent descriptions right now. (and Restro descriptions shown)
![talents](https://vgy.me/aWClYg.jpg)
Only Ascendance (if specced) and Stormkeeper right now
![cds](https://vgy.me/Z7KvG3.jpg)
![procs](https://vgy.me/LK9eU5.jpg)
WIP Maelstrom usage; the spend category needs still some work.
![maelstrom](https://vgy.me/jP5imP.jpg)