### PR TITLE
Fix crash when CBT, AG or Ascendance was cast before pull.

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+07-06-2017 - Resto Shaman: Fix crash when CBT, AG or Ascendance was cast before pull. (by Versaya)
 06-06-2017 - Added refresh button to fights list.
 05-06-2017 - Disc Priest: Fix Atonement duration in cast efficiency not accounting for the Doomsayer trait. (by Zerotorescue)
 05-06-2017 - Discipline Priest: Fixed issue where critical atonement healing was not being counted, fixed Nero's Band of Promises being broken. (By Reglitch)

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -350,6 +350,7 @@ export default {
     id: 157153,
     name: 'Cloudburst Totem',
     icon: 'ability_shaman_condensationtotem',
+    cooldownType: 'HEALING',
     description: 'Cloudburst Totem will in almost all encounters provide the most throughput when used correctly (see the <a href="https://chainheal.com/resto-shaman-guide-on-how-to-maximize-cloudburst-totem-cbt/">cloudburst totem guide</a> on <a href="http://chainheal.com">ChainHeal.com</a>). Extremely strong synergy with <a href="http://www.wowhead.com/spell=108281" target="_blank" rel="noopener noreferrer">Ancestral Guidance</a> and <a href="http://www.wowhead.com/spell=114052" target="_blank" rel="noopener noreferrer">Ascendance</a>.',
   },
   CLOUDBURST_TOTEM_HEAL: {


### PR DESCRIPTION
Fix crash when CBT, AG or Ascendance was cast before pull. Also readds healing statistics to cloudburst totem in the cooldown overview.