### PR TITLE
Holy Priest: SYP and LoT bugfixes

### DIFF
--- a/src/Parser/HolyPriest/CPM_ABILITIES.js
+++ b/src/Parser/HolyPriest/CPM_ABILITIES.js
@@ -1,7 +1,7 @@
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 
-// import ISSUE_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
+import { calculateMaxCasts } from 'Parser/Core/getCastEfficiency';
 
 export const SPELL_CATEGORY = {
   ROTATIONAL: 'Rotational Spell',
@@ -22,6 +22,9 @@ const CPM_ABILITIES = [
     name: 'Light of T\'uure',
     category: SPELL_CATEGORY.ROTATIONAL,
     getCooldown: haste => 45,
+    getMaxCasts: (cooldown, fightDuration, getAbility, parser) => {
+      return calculateMaxCasts(cooldown, fightDuration, 2);
+    },
   },
   {
     spell: SPELLS.DESPERATE_PRAYER,

--- a/src/Parser/HolyPriest/CombatLogParser.js
+++ b/src/Parser/HolyPriest/CombatLogParser.js
@@ -106,8 +106,9 @@ class CombatLogParser extends MainCombatLogParser {
     const rtfRelPercHPS = formatPercentage(this.modules.renewTheFaith.healing / this.modules.divineHymn.healing);
 
     // Say Your Prayers trait data calculations
-    const averagePoMperCast = (this.modules.prayerOfMending.removed - this.modules.renewTheFaith.poms) / getAbility(SPELLS.PRAYER_OF_MENDING_CAST.id).casts;
-    const sypValue = (averagePoMperCast - 5) / averagePoMperCast * this.modules.prayerOfMending.healing;
+    const sypTrait = this.selectedCombatant.traitsBySpellId[SPELLS.SAY_YOUR_PRAYERS_TRAIT.id];
+    const percPomIncFromSYP = ((1 + (sypTrait * SPELLS.SAY_YOUR_PRAYERS_TRAIT.coeff)) / (1 - (sypTrait * SPELLS.SAY_YOUR_PRAYERS_TRAIT.coeff))) - 1;
+    const sypValue = this.modules.prayerOfMending.healing * percPomIncFromSYP / (1 + percPomIncFromSYP);
     const sypHPS = sypValue / this.fightDuration * 1000;
     const sypPercHPSOverall = formatPercentage(sypValue / this.totalHealing);
     const sypPercHPSPoM = formatPercentage(sypValue / this.modules.prayerOfMending.healing);
@@ -188,7 +189,7 @@ class CombatLogParser extends MainCombatLogParser {
         icon={<SpellIcon id={SPELLS.PRAYER_OF_MENDING_CAST.id} />}
         value={`${formatNumber(sypHPS)} HPS`}
         label={(
-          <dfn data-tip={`Approximation of Say Your Prayers' value by viewing average stacks per PoM cast (does not include Benediction renews). This is ${sypPercHPSOverall}% of your healing and ${sypPercHPSPoM}% of your Prayer of Mending healing.`}>
+          <dfn data-tip={`Approximation of Say Your Prayers' value by viewing average stacks per PoM cast (does not include Benediction renews). This is ${sypPercHPSOverall}% of your healing and ~${sypPercHPSPoM}% of your Prayer of Mending healing.`}>
             Say Your Prayers
           </dfn>
         )}

--- a/src/common/SPELLS_PRIEST.js
+++ b/src/common/SPELLS_PRIEST.js
@@ -357,6 +357,13 @@ export default {
     icon: 'spell_holy_divinehymn',
   },
 
+  SAY_YOUR_PRAYERS_TRAIT: {
+    id: 196358,
+    name: 'Say Your Prayers',
+    icon: 'spell_holy_prayerofmendingtga',
+    coeff: 0.06,
+  },
+
   // Buffs
   BLESSING_OF_TUURE_BUFF: {
     id: 196644,


### PR DESCRIPTION
Fixes two bugs with the analyzer:

 * Say Your Prayers was returning negative benefit when the average PoM lasted less than 5 stacks.
 * Light of T'uure was expecting one less cast than it should have (since it starts with 2 charges).