### PR TITLE
better tearstone calculation

### DIFF
--- a/src/Parser/RestoDruid/CombatLogParser.js
+++ b/src/Parser/RestoDruid/CombatLogParser.js
@@ -102,6 +102,77 @@ class CombatLogParser extends MainCombatLogParser {
     darkmoonDeckPromises: DarkmoonDeckPromises,
   };
 
+  /**
+   * when you cast WG and you yourself are one of the targets the applybuff event will be in the events log before the cast event
+   * this can make parsing certain things rather hard, so we need to swap them
+   * @param events
+   * @returns {Array}
+   */
+  reorderEvents(events) {
+    let _events = [];
+    let _newEvents = [];
+
+    events.forEach((event, idx) => {
+      _events.push(event);
+
+      // for WG cast events we look backwards through the events and any applybuff events we push forward
+      if (event.type === "cast" && event.ability.guid === SPELLS.WILD_GROWTH.id) {
+        for (let _idx = idx - 1; _idx >= 0; _idx--) {
+          const _event = _events[_idx];
+
+          if (_event.timestamp !== event.timestamp) {
+            _newEvents.reverse();
+            _events = _events.concat(_newEvents);
+            _newEvents = [];
+            break;
+          }
+
+          if (_event.type === "applybuff" && _event.ability.guid === SPELLS.WILD_GROWTH.id && _event.targetID === this.playerId) {
+            _events.splice(_idx, 1);
+            _newEvents.push(_event);
+          }
+        }
+
+        if (_newEvents.length) {
+          _newEvents.reverse();
+          _events = _events.concat(_newEvents);
+        }
+      }
+
+      if (event.type === "cast" && event.ability.guid === SPELLS.REJUVENATION.id) {
+        for (let _idx = idx - 1; _idx >= 0; _idx--) {
+          const _event = _events[_idx];
+
+          if (_event.timestamp !== event.timestamp) {
+            _newEvents.reverse();
+            _events = _events.concat(_newEvents);
+            _newEvents = [];
+            break;
+          }
+
+          if (_event.type === "applybuff"
+            && [SPELLS.REJUVENATION.id, SPELLS.REJUVENATION_GERMINATION.id].indexOf(_event.ability.guid) !== -1
+            && _event.targetID === event.targetID) {
+            _events.splice(_idx, 1);
+            _newEvents.push(_event);
+          }
+        }
+
+        if (_newEvents.length) {
+          _newEvents.reverse();
+          _events = _events.concat(_newEvents);
+        }
+      }
+    });
+
+    return _events;
+  }
+
+  parseEvents(events) {
+    return super.parseEvents(this.reorderEvents(events));
+  }
+
+
   generateResults() {
     const results = super.generateResults();
     const formatThroughput = healingDone => `${formatPercentage(healingDone / this.totalHealing)} %`;

--- a/src/Parser/RestoDruid/Modules/Legendaries/Tearstone.js
+++ b/src/Parser/RestoDruid/Modules/Legendaries/Tearstone.js
@@ -5,14 +5,25 @@ export const TEARSTONE_ITEM_ID = 137042;
 
 class Tearstone extends Module {
   rejuvs = 0;
+  rejuvTimestamp = null;
+  rejuvTarget = null;
   wildgrowthTimestamp = null;
+  wildGrowthTargets = [];
   wildGrowths = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
 
+    // track rejuv being casted so we don't count a casted rejuv as tearstone proc
+    if (SPELLS.REJUVENATION.id === spellId) {
+      this.rejuvTimestamp = event.timestamp;
+      this.rejuvTarget = event.targetID;
+    }
+
+    // track WG being casted, without WG there's no tearstone procs
     if (SPELLS.WILD_GROWTH.id === spellId) {
       this.wildgrowthTimestamp = event.timestamp;
+      this.wildGrowthTargets = [];
       if (this.owner.selectedCombatant.hasBuff(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id)) {
         this.wildGrowths += 8;
       } else {
@@ -24,7 +35,24 @@ class Tearstone extends Module {
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
 
-    if ((SPELLS.REJUVENATION.id === spellId || SPELLS.REJUVENATION_GERMINATION.id === spellId) && (event.timestamp - this.wildgrowthTimestamp) < 200) {
+    // add WG targets so we can check against those for rejuv buffs
+    if (SPELLS.WILD_GROWTH.id === spellId && (event.timestamp - this.wildgrowthTimestamp) < 200) {
+      this.wildGrowthTargets.push(event.targetID);
+      return;
+    }
+
+    // check if this is a rejuv that was casted
+    if ((SPELLS.REJUVENATION.id === spellId || SPELLS.REJUVENATION_GERMINATION.id === spellId)
+     && event.targetID === this.rejuvTarget && (event.timestamp - this.rejuvTimestamp) < 200) {
+      // "consume" the rejuv cast we were tracking
+      this.rejuvTarget = null;
+      this.rejuvTimestamp = null;
+        return;
+    }
+
+    if ((SPELLS.REJUVENATION.id === spellId || SPELLS.REJUVENATION_GERMINATION.id === spellId)
+      && (event.timestamp - this.wildgrowthTimestamp) < 200
+      && this.wildGrowthTargets.indexOf(event.targetID) !== -1) {
       this.rejuvs++;
     }
   }

--- a/src/tests/Parser/RestoDruid/CombatLogParser.test.js
+++ b/src/tests/Parser/RestoDruid/CombatLogParser.test.js
@@ -1,0 +1,101 @@
+import SPELLS from 'common/SPELLS';
+import CombatLogParser from 'Parser/RestoDruid/CombatLogParser';
+
+describe('RestoDruid.CombatLogParser', () => {
+  const reorderScenarios = [
+    {
+      // 0: simple test to see if the events aren't touched when they're already in order
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: 2, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+      ],
+      result: [1, 2, 3],
+    },
+    {
+      // 1: test if the cast is moved before the applybuff
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+      ],
+      result: [2, 1],
+    },
+    {
+      // 2: test if the cast is moved before the applybuff when there's more events in the same tick
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+        {testid: 4, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION_GERMINATION.id}, type: "applybuff"},
+      ],
+      result: [1, 3, 2, 4],
+    },
+    {
+      // 3: test if nothing is moved when the events are in other ticks
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 2, timestamp: 2, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+      ],
+      result: [1, 2],
+    },
+    {
+      // 4: test if the cast is moved before the applybuff when there's more events in other ticks
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+        {testid: 4, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION_GERMINATION.id}, type: "applybuff"},
+      ],
+      result: [1, 3, 2, 4],
+    },
+    {
+      // 5: test if only the applybuff to the player is moved
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 2, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+      ],
+      result: [2, 3, 1],
+    },
+    {
+      // 6: test if it works for rejuv
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "cast"},
+      ],
+      result: [2, 1],
+    },
+    {
+      // 7: test if it works for rejuv germ
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION_GERMINATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "cast"},
+      ],
+      result: [2, 1],
+    },
+    {
+      // 8: test if only the applybuff to the player is moved
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 2, ability: {guid: SPELLS.REJUVENATION.id}, type: "cast"},
+      ],
+      result: [1, 2],
+    },
+  ];
+
+  reorderScenarios.forEach((scenario, idx) => {
+    it('can reorder events ' + idx, () => {
+      const parser = new CombatLogParser(null, {id: scenario.playerId});
+      expect(parser.reorderEvents(scenario.events).map((event) => { return event.testid; })).toEqual(scenario.result);
+    });
+  });
+});


### PR DESCRIPTION
track people who received WG buff, only those could have been the target of a tearstone proc.  
and track rejuv casts to avoid counting casted rejuvs that occur at the same time as tearstone proc.

depends on the other PR to fix the order of cast/applybuff events that kinda is needed for tearstone tracking to work well: https://github.com/MartijnHols/WoWAnalyzer/pull/107