### PR TITLE
reorder WG and rejuv cast/applybuff events to fix issues we run into later on

### DIFF
--- a/src/Parser/RestoDruid/CombatLogParser.js
+++ b/src/Parser/RestoDruid/CombatLogParser.js
@@ -102,6 +102,77 @@ class CombatLogParser extends MainCombatLogParser {
     darkmoonDeckPromises: DarkmoonDeckPromises,
   };
 
+  /**
+   * when you cast WG and you yourself are one of the targets the applybuff event will be in the events log before the cast event
+   * this can make parsing certain things rather hard, so we need to swap them
+   * @param events
+   * @returns {Array}
+   */
+  reorderEvents(events) {
+    let _events = [];
+    let _newEvents = [];
+
+    events.forEach((event, idx) => {
+      _events.push(event);
+
+      // for WG cast events we look backwards through the events and any applybuff events we push forward
+      if (event.type === "cast" && event.ability.guid === SPELLS.WILD_GROWTH.id) {
+        for (let _idx = idx - 1; _idx >= 0; _idx--) {
+          const _event = _events[_idx];
+
+          if (_event.timestamp !== event.timestamp) {
+            _newEvents.reverse();
+            _events = _events.concat(_newEvents);
+            _newEvents = [];
+            break;
+          }
+
+          if (_event.type === "applybuff" && _event.ability.guid === SPELLS.WILD_GROWTH.id && _event.targetID === this.playerId) {
+            _events.splice(_idx, 1);
+            _newEvents.push(_event);
+          }
+        }
+
+        if (_newEvents.length) {
+          _newEvents.reverse();
+          _events = _events.concat(_newEvents);
+        }
+      }
+
+      if (event.type === "cast" && event.ability.guid === SPELLS.REJUVENATION.id) {
+        for (let _idx = idx - 1; _idx >= 0; _idx--) {
+          const _event = _events[_idx];
+
+          if (_event.timestamp !== event.timestamp) {
+            _newEvents.reverse();
+            _events = _events.concat(_newEvents);
+            _newEvents = [];
+            break;
+          }
+
+          if (_event.type === "applybuff"
+            && [SPELLS.REJUVENATION.id, SPELLS.REJUVENATION_GERMINATION.id].indexOf(_event.ability.guid) !== -1
+            && _event.targetID === event.targetID) {
+            _events.splice(_idx, 1);
+            _newEvents.push(_event);
+          }
+        }
+
+        if (_newEvents.length) {
+          _newEvents.reverse();
+          _events = _events.concat(_newEvents);
+        }
+      }
+    });
+
+    return _events;
+  }
+
+  parseEvents(events) {
+    return super.parseEvents(this.reorderEvents(events));
+  }
+
+
   generateResults() {
     const results = super.generateResults();
     const formatThroughput = healingDone => `${formatPercentage(healingDone / this.totalHealing)} %`;

--- a/src/tests/Parser/RestoDruid/CombatLogParser.test.js
+++ b/src/tests/Parser/RestoDruid/CombatLogParser.test.js
@@ -1,0 +1,101 @@
+import SPELLS from 'common/SPELLS';
+import CombatLogParser from 'Parser/RestoDruid/CombatLogParser';
+
+describe('RestoDruid.CombatLogParser', () => {
+  const reorderScenarios = [
+    {
+      // 0: simple test to see if the events aren't touched when they're already in order
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: 2, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+      ],
+      result: [1, 2, 3],
+    },
+    {
+      // 1: test if the cast is moved before the applybuff
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+      ],
+      result: [2, 1],
+    },
+    {
+      // 2: test if the cast is moved before the applybuff when there's more events in the same tick
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+        {testid: 4, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION_GERMINATION.id}, type: "applybuff"},
+      ],
+      result: [1, 3, 2, 4],
+    },
+    {
+      // 3: test if nothing is moved when the events are in other ticks
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 2, timestamp: 2, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+      ],
+      result: [1, 2],
+    },
+    {
+      // 4: test if the cast is moved before the applybuff when there's more events in other ticks
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: null, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+        {testid: 4, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION_GERMINATION.id}, type: "applybuff"},
+      ],
+      result: [1, 3, 2, 4],
+    },
+    {
+      // 5: test if only the applybuff to the player is moved
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 2, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "applybuff"},
+        {testid: 3, timestamp: 1, targetID: 1, ability: {guid: SPELLS.WILD_GROWTH.id}, type: "cast"},
+      ],
+      result: [2, 3, 1],
+    },
+    {
+      // 6: test if it works for rejuv
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "cast"},
+      ],
+      result: [2, 1],
+    },
+    {
+      // 7: test if it works for rejuv germ
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION_GERMINATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "cast"},
+      ],
+      result: [2, 1],
+    },
+    {
+      // 8: test if only the applybuff to the player is moved
+      playerId: 1,
+      events: [
+        {testid: 1, timestamp: 1, targetID: 1, ability: {guid: SPELLS.REJUVENATION.id}, type: "applybuff"},
+        {testid: 2, timestamp: 1, targetID: 2, ability: {guid: SPELLS.REJUVENATION.id}, type: "cast"},
+      ],
+      result: [1, 2],
+    },
+  ];
+
+  reorderScenarios.forEach((scenario, idx) => {
+    it('can reorder events ' + idx, () => {
+      const parser = new CombatLogParser(null, {id: scenario.playerId});
+      expect(parser.reorderEvents(scenario.events).map((event) => { return event.testid; })).toEqual(scenario.result);
+    });
+  });
+});


### PR DESCRIPTION
When parsing resto druid logs in the past with my own tool (https://github.com/rubensayshi/wcl-rdruid-mastery) I've noticed that sometimes `applybuff` events occur before the `cast` even that applied the buff.  
For resto druid there's a couple of things that make it rather important that the events are in the right order, there's so many HoTs proccing from various things that if they are not it's impossible to attribute them to the right legendaries and talents.

As an example you can look at `/report/WP6brRpDChmGFT9H/6/Saik%C3%B3/cast-efficiency`.

If you put a `console.log` in `Tearstone.js` to log the WG `cast` and `applybuff` events you will see the following (timestamp has been normalized to start of fight and seconds, the number before the timestamp is `targetID`):

```
APPLYBUFF:WG 14 240.487
Tearstone.js:16 CAST:WG 240.487
Tearstone.js:32 APPLYBUFF:WG 3 240.487
Tearstone.js:32 APPLYBUFF:WG 13 240.487
Tearstone.js:32 APPLYBUFF:WG 1 240.487
Tearstone.js:32 APPLYBUFF:WG 9 240.487
Tearstone.js:32 APPLYBUFF:WG 48 240.487
Tearstone.js:32 APPLYBUFF:WG 14 254.617

APPLYBUFF:WG 14 270.201
Tearstone.js:16 CAST:WG 270.201
Tearstone.js:32 APPLYBUFF:WG 29 270.201
Tearstone.js:32 APPLYBUFF:WG 21 270.201
Tearstone.js:32 APPLYBUFF:WG 9 270.201
Tearstone.js:32 APPLYBUFF:WG 15 270.201
Tearstone.js:32 APPLYBUFF:WG 25 270.201

APPLYBUFF:WG 14 290.534
Tearstone.js:16 CAST:WG 290.534
Tearstone.js:32 APPLYBUFF:WG 3 290.559
Tearstone.js:32 APPLYBUFF:WG 21 290.559
Tearstone.js:32 APPLYBUFF:WG 9 290.559
Tearstone.js:32 APPLYBUFF:WG 25 290.559
Tearstone.js:32 APPLYBUFF:WG 28 290.559
```

As you can see sometimes the `applybuff` occurs before the `cast`, but it seems like it only happens when it's the player himself getting a WG HoT from his own cast.

The same issue occurs with Rejuv.

Tbh in my own tool I have more stuff to reorder events, but I'm not sure anymore what things they each fixed and I don't want to have a huge PR anyway, so this is just the first thing that needs fixing, because it affects my other open PR to fix tearstone parsing (https://github.com/MartijnHols/WoWAnalyzer/pull/105) 