### PR TITLE
Bugfix/check class resource with type

### DIFF
--- a/src/Parser/Core/Modules/Items/PrePotion.js
+++ b/src/Parser/Core/Modules/Items/PrePotion.js
@@ -22,6 +22,8 @@ const DURATION = 30000;
 const DURATION_PROLONGED = 60000;
 const ANCIENT_MANA_POTION_AMOUNT = 152000;
 
+const MANA_CLASS_RESOURCE_ID = 0;
+
 class PrePotion extends Module {
   usedPrePotion = false;
   usedSecondPotion = false;
@@ -51,7 +53,7 @@ class PrePotion extends Module {
     }
 
     // class resource type 0 means the resource is mana
-    if (event.classResources && event.classResources[0] && event.classResources[0].type === 0) {
+    if (event.classResources && event.classResources[0] && event.classResources[0].type === MANA_CLASS_RESOURCE_ID) {
       const resource = event.classResources[0];
       const manaLeftAfterCast = resource.amount - resource.cost;
       if (manaLeftAfterCast < ANCIENT_MANA_POTION_AMOUNT) {

--- a/src/Parser/Core/Modules/Items/PrePotion.js
+++ b/src/Parser/Core/Modules/Items/PrePotion.js
@@ -50,7 +50,8 @@ class PrePotion extends Module {
       this.usedSecondPotion = true;
     }
 
-    if (event.classResources && event.classResources[0]) {
+    // class resource type 0 means the resource is mana
+    if (event.classResources && event.classResources[0] && event.classResources[0].type === 0) {
       const resource = event.classResources[0];
       const manaLeftAfterCast = resource.amount - resource.cost;
       if (manaLeftAfterCast < ANCIENT_MANA_POTION_AMOUNT) {


### PR DESCRIPTION
We are currently using `event.classResources[0]` as mana. 
But for some specs, like elemental shaman, it can be other resources.

For example:
In this report: https://www.warcraftlogs.com/reports/byjrFKhCWm1DY2nV/#fight=5&source=56
If we console the event with class resource we will get:
```
{"amount":13,"max":125,"type":11}
{"amount":18,"max":125,"type":11}
...
```
Seems we get maelstorm as class resource and this will cause the `neededManaSecondPotion` check went wrong.

To fix this I add a check on resource type, only resource with type 0 means it is mana.

It seems we still have several check base on class resource without checking type, should I change it?