### PR TITLE
Change to the damage done calculation to better reflect value in logs

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -213,8 +213,14 @@ class CombatLogParser {
   }
 
   totalDamageDone = 0;
+  totalDamageDoneToFriendly = 0;
   on_byPlayer_damage(event) {
-    this.totalDamageDone += event.amount + (event.absorbed || 0);
+    if (event.targetIsFriendly) {
+      this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0) - (event.blocked !== undefined ? event.blocked : 0);
+    }
+    else {
+      this.totalDamageDone += event.amount + (event.absorbed || 0) - (event.blocked !== undefined ? event.blocked : 0);
+    }
   }
   totalDamageTaken = 0;
   on_toPlayer_damage(event) {

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -215,11 +215,11 @@ class CombatLogParser {
   totalDamageDone = 0;
   totalDamageDoneToFriendly = 0;
   on_byPlayer_damage(event) {
+    const damageDone = event.amount + (event.absorbed || 0);
     if (event.targetIsFriendly) {
-      this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0);
-    }
-    else {
-      this.totalDamageDone += event.amount + (event.absorbed || 0);
+      this.totalDamageDoneToFriendly += damageDone;
+    } else {
+      this.totalDamageDone += damageDone;
     }
   }
   totalDamageTaken = 0;

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -216,10 +216,10 @@ class CombatLogParser {
   totalDamageDoneToFriendly = 0;
   on_byPlayer_damage(event) {
     if (event.targetIsFriendly) {
-      this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0) - (event.blocked || 0);
+      this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0);
     }
     else {
-      this.totalDamageDone += event.amount + (event.absorbed || 0) - (event.blocked || 0);
+      this.totalDamageDone += event.amount + (event.absorbed || 0);
     }
   }
   totalDamageTaken = 0;

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -216,10 +216,10 @@ class CombatLogParser {
   totalDamageDoneToFriendly = 0;
   on_byPlayer_damage(event) {
     if (event.targetIsFriendly) {
-      this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0) - (event.blocked !== undefined ? event.blocked : 0);
+      this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0) - (event.blocked || 0);
     }
     else {
-      this.totalDamageDone += event.amount + (event.absorbed || 0) - (event.blocked !== undefined ? event.blocked : 0);
+      this.totalDamageDone += event.amount + (event.absorbed || 0) - (event.blocked || 0);
     }
   }
   totalDamageTaken = 0;


### PR DESCRIPTION
This may prompt further discussion:

Example: Goroth
If you hit another player with your Burning Eruption targetisfriendly is set to true in the event. However damage done in warcraftlogs does not show this in your damage done.

Friendly damage is added to totalDamageDoneToFriendly rather than totalDamageDone
`this.totalDamageDoneToFriendly += event.amount + (event.absorbed || 0);`

In order to match the log value i think totalDamageDone should be the value in the logs and exclude friendly damage, but if that messes with some other calculation then leaving it included but with a seperate totalDamageDoneToFriendly value which you would have to subtract is an alternative. It would be less intuitive for authors of dps parsers. 