### PR TITLE
Change to the CombatLogParser to match warcraftlogs.com

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -220,7 +220,7 @@ class CombatLogParser {
   totalDamageTaken = 0;
   totalDamageTakenAbsorb = 0;
   on_toPlayer_damage(event) {
-    this.totalDamageTaken += event.amount;
+    this.totalDamageTaken += event.amount + (event.absorbed || 0);
     this.totalDamageTakenAbsorb += (event.absorbed || 0);
   }
 

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -216,9 +216,12 @@ class CombatLogParser {
   on_byPlayer_damage(event) {
     this.totalDamageDone += event.amount + (event.absorbed || 0);
   }
+  
   totalDamageTaken = 0;
+  totalDamageTakenAbsorb = 0;
   on_toPlayer_damage(event) {
-    this.totalDamageTaken += event.amount + (event.absorbed || 0);
+    this.totalDamageTaken += event.amount;
+    this.totalDamageTakenAbsorb += (event.absorbed || 0);
   }
 
   // TODO: Damage taken from LOTM


### PR DESCRIPTION
This is a separate PR from 138 though related it is a separate issue. This is the same file as the other PR...

The damage taken includes absorbs, while this may be correct in certain circumstances it does not match the value in the logs.

I have introduced a new value so that the absorb is not lost (in case its used elsewhere), but that could be removed if its not needed.