### PR TITLE
Change to end time calculation to account for end of fight

### DIFF
--- a/src/Parser/Core/Entity.js
+++ b/src/Parser/Core/Entity.js
@@ -32,7 +32,7 @@ class Entity {
   getBuffUptime(buffAbilityId) {
     return this.buffs
       .filter(buff => buff.ability.guid === buffAbilityId)
-      .reduce((uptime, buff) => uptime + (buff.end || this.owner.currentTimestamp) - buff.start, 0);
+      .reduce((uptime, buff) => uptime + (buff.end || (this.owner.finished ? this.owner.fight.end_time : this.owner.currentTimestamp)) - buff.start, 0);
   }
   getBuffTriggerCount(buffAbilityId) {
     return this.buffs


### PR DESCRIPTION
I have an issue with getBuffUptime where it appears to be a few 10ths of a second off, and it appears to be because its using this.owner.currentTimestamp as the end of the fight. However that's the time of the last event in the combat log.

I have changed getBuffUptime to account for the end of the fight if its over in a similar way to fightDuration in the core/CombatLogParser.

However this method is used in multiple locations, though it only affects combatant buff uptimes not enemies. Other Parsers need to be tested.