### PR TITLE
Guardian druid damage detail

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+12-08-2017 - Guardian Druid: Added damage type into the tooltip of damage taken, added logic for Pulverize and minor fixes. (by wopr)
 09-08-2017 - Mistweaver Monk: Bug Fix for Dancing Mist calculation and Ending Mana. (by anomoly)
 09-08-2017 - Healers with a <i>non-healing time</i> statistic will no longer have their <i>dead GCD time</i> suggestion marked as major importance. (by Zerotorescue)
 09-08-2017 - Holy Paladin: fully migrated to the new suggestions layout. Changed wording on several suggestions to make them clearer, and increased the <i>LotM is inefficient</i> suggestion breakpoints to 1.5/2/3 CPM (up from 1.0/1.5/2.0) (by Zerotorescue)

--- a/src/Parser/GuardianDruid/CombatLogParser.js
+++ b/src/Parser/GuardianDruid/CombatLogParser.js
@@ -36,13 +36,20 @@ function getIssueImportance(value, regular, major, higherIsWorse = false) {
   }
   return ISSUE_IMPORTANCE.MINOR;
 }
+
 const damageType = {
   1: 'Physical',
   2: 'Holy',
   4: 'Fire',
   8: 'Nature',
   16: 'Frost',
+  28: 'Elemental',
   32: 'Shadow',
+  33: 'Shadowstrike',
+  34: 'Twilight',
+  36: 'Shadowflame',
+  40: 'Plague',
+  48: 'Shadowfrost',
   64: 'Arcane',
   96: 'Spellshadow',
   100: 'Special',
@@ -51,7 +58,6 @@ const damageType = {
 
 function getMagicDescription(type) {
   if (damageType[type] === undefined) {
-    console.log(type);
     return 'Chaos';
   }
   return damageType[type];


### PR DESCRIPTION
Added damage type to the tooltip of DTPS, this object can also be used later for damage reduction calculations. Damage type is a bitwise property, and chaos damage is not always the same so put a default of chaos and populated all of the other types of damage i could find in the object.