### PR TITLE
[Guardian] Moved all of the druid suggestions and statistics into modules

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+18-08-2017 - Guardian Druid: Updates to align with new module structure and added overkill into DTPS display
 16-08-2017 - Mistweaver Monk: Soothing Mist suggestion added (by anomoly)
 16-08-2017 - Mistweaver Monk: Added the effective healing contribute of Enveloping Mists as a statistic (by anomoly)
 15-08-2017 - Mistweaver Monk: Updates to Mistweaver module to align with new module structure. No information should be lost, but this will be moved around (by anomoly)

--- a/src/Parser/Core/Modules/DamageTaken.js
+++ b/src/Parser/Core/Modules/DamageTaken.js
@@ -1,0 +1,45 @@
+import Module from 'Parser/Core/Module';
+import { getMagicDescription } from 'common/DamageTypes.js';
+
+const debug = false;
+
+class DamageValue {
+  Amount = 0;
+  Absorb = 0;
+  Overkill = 0;
+
+  get Total() {
+    return this.Amount + this.Absorb + this.Overkill;
+  }
+
+  AddDamage(event) {
+    this.Amount += event.amount || 0;
+    this.Absorb += event.absorbed || 0;
+    this.Overkill += event.overkill || 0;
+  }
+}
+
+class DamageTaken extends Module {
+  DamageBySchool = {};
+  DamageByAbility = {};
+  TotalDamage = new DamageValue();
+
+  on_toPlayer_damage(event) {
+    const type = getMagicDescription(event.ability.type);
+    if (this.DamageBySchool[type] === undefined) {
+      this.DamageBySchool[type] = new DamageValue();
+    }
+    if (this.DamageByAbility[event.ability.name] === undefined) {
+      this.DamageByAbility[event.ability.name] = new DamageValue();
+    }
+    this.DamageBySchool[type].AddDamage(event);
+    this.DamageByAbility[event.ability.name].AddDamage(event);
+    this.TotalDamage.AddDamage(event);
+  }
+
+  on_finished() {
+    debug && console.log(this);
+  }
+}
+
+export default DamageTaken;

--- a/src/Parser/Core/Modules/DamageTaken.js
+++ b/src/Parser/Core/Modules/DamageTaken.js
@@ -1,5 +1,6 @@
 import Module from 'Parser/Core/Module';
 import { getMagicDescription } from 'common/DamageTypes.js';
+import SPELLS from 'common/SPELLS';
 
 const debug = false;
 
@@ -23,8 +24,15 @@ class DamageTaken extends Module {
   DamageBySchool = {};
   DamageByAbility = {};
   TotalDamage = new DamageValue();
+  ShamanTotem = new DamageValue();
 
   on_toPlayer_damage(event) {
+    // In the logs this is not counted as damage but negative healing, seperating it out here in case someone wants to access this.
+    // TODO: I think there is a paladin mechanic that appears the same, though i am unsure if it affects the damage taken.
+    if (event.ability.guid === SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE.id) {
+      this.ShamanTotem.AddDamage(event);
+      return;
+    }
     const type = getMagicDescription(event.ability.type);
     if (this.DamageBySchool[type] === undefined) {
       this.DamageBySchool[type] = new DamageValue();

--- a/src/Parser/GuardianDruid/CombatLogParser.js
+++ b/src/Parser/GuardianDruid/CombatLogParser.js
@@ -1,264 +1,65 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
-import Icon from 'common/Icon';
-import { formatThousands, formatNumber, formatPercentage } from 'common/format';
-// Currently Unused
-// import ITEMS from 'common/ITEMS';
-// import ItemLink from 'common/ItemLink';
-// import ItemIcon from 'common/ItemIcon';
-
-import StatisticBox from 'Main/StatisticBox';
 import SuggestionsTab from 'Main/SuggestionsTab';
 import Tab from 'Main/Tab';
 import Talents from 'Main/Talents';
 import MainCombatLogParser from 'Parser/Core/CombatLogParser';
-import ISSUE_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
 
 import CastEfficiency from './Modules/Features/CastEfficiency';
 
+import DamageTaken from './Modules/Core/DamageTaken';
+import HealingDone from './Modules/Core/HealingDone';
+import DamageDone from './Modules/Core/DamageDone';
 import Gore from './Modules/Features/Gore';
 import GalacticGuardian from './Modules/Features/GalacticGuardian';
 import GuardianOfElune from './Modules/Features/GuardianOfElune';
+import IronFurGoEProcs from './Modules/Features/IronFurGoEProcs';
+import FrenziedRegenGoEProcs from './Modules/Features/FrenziedRegenGoEProcs';
+import IronFur from './Modules/Spells/IronFur';
+import Thrash from './Modules/Spells/Thrash';
+import Moonfire from './Modules/Spells/Moonfire';
+import Pulverize from './Modules/Spells/Pulverize';
 import DualDetermination from './Modules/Items/DualDetermination';
 
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 
-function getIssueImportance(value, regular, major, higherIsWorse = false) {
-  if (higherIsWorse ? value > major : value < major) {
-    return ISSUE_IMPORTANCE.MAJOR;
-  }
-  if (higherIsWorse ? value > regular : value < regular) {
-    return ISSUE_IMPORTANCE.REGULAR;
-  }
-  return ISSUE_IMPORTANCE.MINOR;
-}
-
-const damageType = {
-  1: 'Physical',
-  2: 'Holy',
-  4: 'Fire',
-  8: 'Nature',
-  16: 'Frost',
-  28: 'Elemental',
-  32: 'Shadow',
-  33: 'Shadowstrike',
-  34: 'Twilight',
-  36: 'Shadowflame',
-  40: 'Plague',
-  48: 'Shadowfrost',
-  64: 'Arcane',
-  96: 'Spellshadow',
-  100: 'Special',
-  124: 'Chaos',
-};
-
-function getMagicDescription(type) {
-  if (damageType[type] === undefined) {
-    return 'Chaos';
-  }
-  return damageType[type];
-}
-
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
+    //Core 
+    damageTaken: DamageTaken,
+    healingDone: HealingDone,
+    damageDone: DamageDone,
     // Features
     castEfficiency: CastEfficiency,
     alwaysBeCasting: AlwaysBeCasting,
     goreProcs: Gore,
     galacticGuardianProcs: GalacticGuardian,
     guardianOfEluneProcs: GuardianOfElune,
-
+    ironFurGoEProcs: IronFurGoEProcs,
+    frenziedRegenGoEProcs: FrenziedRegenGoEProcs,
+    ironFur: IronFur,
+    thrash: Thrash,
+    moonfire: Moonfire,
+    pulverize: Pulverize,
+    
     // Legendaries:
     dualDetermination: DualDetermination,
   };
 
   damageBySchool = {};
+  totalOverkill = 0;
   on_toPlayer_damage(event) {
     if (this.damageBySchool[event.ability.type] === undefined) {
       this.damageBySchool[event.ability.type] = 0;
     }
-    this.damageBySchool[event.ability.type] += event.amount + (event.absorbed || 0);
+    this.damageBySchool[event.ability.type] += event.amount + (event.absorbed || 0) + (event.overkill || 0);
+    // Unsure at this point if this should be added to the super class total, keeping seperate for now...
+    this.totalOverkill += event.overkill || 0;
     super.on_toPlayer_damage(event);
   }
 
   generateResults() {
     const results = super.generateResults();
-
-    const fightDuration = this.fightDuration;
-
-    const nonDpsTimePercentage = this.modules.alwaysBeCasting.totalDamagingTimeWasted / fightDuration;
-    const deadTimePercentage = this.modules.alwaysBeCasting.totalTimeWasted / fightDuration;
-    const unusedGoreProcs = 1 - (this.modules.goreProcs.consumedGoreProc / this.modules.goreProcs.GoreProcsTotal);
-    const unusedGGProcs = 1 - (this.modules.galacticGuardianProcs.consumedGGProc / this.modules.galacticGuardianProcs.GGProcsTotal);
-    const unusedGoEProcs = 1 - (this.modules.guardianOfEluneProcs.consumedGoEProc / this.modules.guardianOfEluneProcs.GoEProcsTotal);
-
-    const thrashUptimePercentage = this.modules.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.fightDuration;
-    const moonfireUptimePercentage = this.modules.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.fightDuration;
-
-    const totalIronFurTime = this.selectedCombatant.getBuffUptime(SPELLS.IRONFUR.id);
-    const pulverizeUptimePercentage = this.selectedCombatant.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.fightDuration;
-    
-    if (nonDpsTimePercentage > 0.3) {
-      results.addIssue({
-        issue: `Your non DPS time can be improved. Try to cast damaging spells more regularly.`,
-        stat: `${Math.round(nonDpsTimePercentage * 100)}% non DPS time (<30% is recommended)`,
-        icon: 'petbattle_health-down',
-        importance: getIssueImportance(nonDpsTimePercentage, 0.4, 0.45, true),
-      });
-    }
-    if (deadTimePercentage > 0.2) {
-      results.addIssue({
-        issue: `Your dead GCD time can be improved. Try to Always Be Casting (ABC).`,
-        stat: `${Math.round(deadTimePercentage * 100)}% dead GCD time (<20% is recommended)`,
-        icon: 'spell_mage_altertime',
-        importance: getIssueImportance(deadTimePercentage, 0.35, 0.4, true),
-      });
-    }
-    if (unusedGoreProcs > 0.30) {
-      results.addIssue({
-        issue: <span>Your <SpellLink id={SPELLS.GORE_BEAR.id} /> procs should be used as soon as you get them so they are not overwritten.</span>,
-        stat: `${(this.modules.goreProcs.GoreProcsTotal - this.modules.goreProcs.consumedGoreProc)}/${(this.modules.goreProcs.GoreProcsTotal)} (${formatPercentage((this.modules.goreProcs.GoreProcsTotal - this.modules.goreProcs.consumedGoreProc) / this.modules.goreProcs.GoreProcsTotal)}%) procs were missed (<30% is recommended)`,
-        icon: SPELLS.GORE_BEAR.icon,
-        importance: getIssueImportance(unusedGoreProcs, 0.45, 0.6, true),
-      });
-    }
-    if (unusedGGProcs > 0.30) {
-      results.addIssue({
-        issue: <span>Your <SpellLink id={SPELLS.GALACTIC_GUARDIAN.id} /> procs should be used as soon as you get them so they are not overwritten.</span>,
-        stat: `${(this.modules.galacticGuardianProcs.GGProcsTotal - this.modules.galacticGuardianProcs.consumedGGProc)}/${(this.modules.galacticGuardianProcs.GGProcsTotal)} (${formatPercentage((this.modules.galacticGuardianProcs.GGProcsTotal - this.modules.galacticGuardianProcs.consumedGGProc) / this.modules.galacticGuardianProcs.GGProcsTotal)}%) procs were missed (<30% is recommended)`,
-        icon: SPELLS.GALACTIC_GUARDIAN.icon,
-        importance: getIssueImportance(unusedGGProcs, 0.45, 0.6, true),
-      });
-    }
-    if (unusedGoEProcs > 0.30) {
-      results.addIssue({
-        issue: <span>Your <SpellLink id={SPELLS.GUARDIAN_OF_ELUNE.id} /> procs should be used as soon as you get them so they are not overwritten.</span>,
-        stat: `${(this.modules.guardianOfEluneProcs.GoEProcsTotal - this.modules.guardianOfEluneProcs.consumedGoEProc)}/${(this.modules.guardianOfEluneProcs.GoEProcsTotal)} (${formatPercentage((this.modules.guardianOfEluneProcs.GoEProcsTotal - this.modules.guardianOfEluneProcs.consumedGoEProc) / this.modules.guardianOfEluneProcs.GoEProcsTotal)}%) procs were missed (<30% recommended)`,
-        icon: SPELLS.GUARDIAN_OF_ELUNE.icon,
-        importance: getIssueImportance(unusedGoEProcs, 0.45, 0.6, true),
-      });
-    }
-
-    if (thrashUptimePercentage < 0.95) {
-      results.addIssue({
-        issue: <span> Your <SpellLink id={SPELLS.THRASH_BEAR_DOT.id} /> uptime should be near 100%, unless you have extended periods of downtime. Thrash applies a bleed which buffs the damage of <SpellLink id={SPELLS.MANGLE_BEAR.id} /> by 20%.  Thrash uptime is especially important if you are talented into <SpellLink id={SPELLS.REND_AND_TEAR_TALENT.id} />, since it buffs the rest of your damage and gives you extra damage reduction.</span>,
-        stat: `${formatPercentage(thrashUptimePercentage)}% uptime (>95% recommended)`,
-        icon: SPELLS.THRASH_BEAR.icon,
-        importance: getIssueImportance(thrashUptimePercentage, 0.9, 0.8),
-      });
-    }
-
-    if (moonfireUptimePercentage < 0.95) {
-      results.addIssue({
-        issue: <span> Your <SpellLink id={SPELLS.MOONFIRE_BEAR.id} /> uptime should be near 100%, unless you have extended periods of downtime. Targets with Moonfire applied to them deal less damage to you due to <SpellLink id={SPELLS.SCINTILLATING_MOONLIGHT.id} />.</span>,
-        stat: `${formatPercentage(moonfireUptimePercentage)}% uptime (>95% recommended)`,
-        icon: SPELLS.MOONFIRE_BEAR.icon,
-        importance: getIssueImportance(moonfireUptimePercentage, 0.9, 0.8),
-      });
-    }
-
-    if (this.selectedCombatant.hasTalent(SPELLS.PULVERIZE_TALENT.id) && pulverizeUptimePercentage < 0.9) {
-      results.addIssue({
-        issue: <span> Your <SpellLink id={SPELLS.PULVERIZE_TALENT.id} /> uptime should be near 100%, unless there are extended periods of downtime. All targets deal less damage to you due to the <SpellLink id={SPELLS.PULVERIZE_BUFF.id} /> buff.</span>,
-        stat: `${formatPercentage(pulverizeUptimePercentage)}% uptime (>90% recommended)`,
-        icon: SPELLS.PULVERIZE_TALENT.icon,
-        importance: getIssueImportance(pulverizeUptimePercentage, 0.9, 0.75),
-      });
-    }
-
-    results.statistics = [
-      <StatisticBox
-        icon={<Icon icon="class_druid" alt="Damage taken" />}
-        value={`${formatNumber(this.totalDamageTaken / this.fightDuration * 1000)} DTPS`}
-        label='Damage taken'
-        tooltip={`Damage taken breakdown:
-            <ul>
-              ${Object.keys(this.damageBySchool).reduce((v, x) => {return v+=`<li>${getMagicDescription(x)} damage taken ${formatThousands(this.damageBySchool[x])} (${formatPercentage(this.damageBySchool[x]/this.totalDamageTaken)}%)</li>`; }, '')}
-            </ul>
-            Total damage taken ${formatThousands(this.totalDamageTaken)}`}
-      />,
-      <StatisticBox
-        icon={(
-          <img
-            src="/img/healing.png"
-            style={{ border: 0 }}
-            alt="Healing"
-          />
-        )}
-        value={`${formatNumber(this.totalHealing / this.fightDuration * 1000)} HPS`}
-        label='Healing done'
-        tooltip={`The total healing done was ${formatThousands(this.totalHealing)}.`}
-      />,
-      <StatisticBox
-        icon={<Icon icon="spell_mage_altertime" alt="Dead GCD time" />}
-        value={`${formatPercentage(deadTimePercentage)} %`}
-        label='Dead GCD time'
-        tooltip='Dead GCD time is available casting time not used. This can be caused by latency, cast interrupting, not casting anything (e.g. due to movement/stunned), etc.'
-      />,
-      <StatisticBox
-        icon={<Icon icon="class_druid" alt="Damage done" />}
-        value={`${formatNumber(this.totalDamageDone / this.fightDuration * 1000)} DPS`}
-        label='Damage done'
-        tooltip={`The total damage done was ${formatThousands(this.totalDamageDone)}.`}
-      />,
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.GORE_BEAR.id} />}
-        value={`${formatPercentage(unusedGoreProcs)}%`}
-        label='Unused Gore Procs'
-        tooltip={`You got total <b>${this.modules.goreProcs.GoreProcsTotal}</b> gore procs and <b>used ${this.modules.goreProcs.consumedGoreProc}</b> of them.`}
-      />,
-      this.modules.galacticGuardianProcs.active && (<StatisticBox
-        icon={<SpellIcon id={SPELLS.GALACTIC_GUARDIAN.id} />}
-        value={`${formatPercentage(unusedGGProcs)}%`}
-        label='Unused Galactic Guardian'
-        tooltip={`You got total <b>${this.modules.galacticGuardianProcs.GGProcsTotal}</b> galactic guardian procs and <b>used ${this.modules.galacticGuardianProcs.consumedGGProc}</b> of them.`}
-      />),
-      this.modules.guardianOfEluneProcs.active && (<StatisticBox
-        icon={<SpellIcon id={SPELLS.GUARDIAN_OF_ELUNE.id} />}
-        value={`${formatPercentage(unusedGoEProcs)}%`}
-        label='Unused Guardian of Elune'
-        tooltip={`You got total <b>${this.modules.guardianOfEluneProcs.GoEProcsTotal}</b> guardian of elune procs and <b>used ${this.modules.guardianOfEluneProcs.consumedGoEProc}</b> of them.`}
-      />),
-      this.modules.guardianOfEluneProcs.active && (<StatisticBox
-        icon={<SpellIcon id={SPELLS.FRENZIED_REGENERATION.id} />}
-        value={`${formatPercentage(this.modules.guardianOfEluneProcs.nonGoEFRegen/(this.modules.guardianOfEluneProcs.nonGoEFRegen + this.modules.guardianOfEluneProcs.GoEFRegen))}%`}
-        label='Unbuffed Frenzied Regen'
-        tooltip={`You cast <b>${this.modules.guardianOfEluneProcs.nonGoEFRegen + this.modules.guardianOfEluneProcs.GoEFRegen}</b> total ${SPELLS.FRENZIED_REGENERATION.name} and <b> ${this.modules.guardianOfEluneProcs.GoEFRegen} were buffed by 25%</b>.`}
-      />),
-      this.modules.guardianOfEluneProcs.active && (<StatisticBox
-        icon={<SpellIcon id={SPELLS.IRONFUR.id} />}
-        value={`${formatPercentage(this.modules.guardianOfEluneProcs.nonGoEIronFur/(this.modules.guardianOfEluneProcs.nonGoEIronFur + this.modules.guardianOfEluneProcs.GoEIronFur))}%`}
-        label='Unbuffed Ironfur'
-        tooltip={`You cast <b>${this.modules.guardianOfEluneProcs.nonGoEIronFur + this.modules.guardianOfEluneProcs.GoEIronFur}</b> total ${SPELLS.IRONFUR.name} and <b> ${this.modules.guardianOfEluneProcs.GoEIronFur} were buffed by 25%</b>.`}
-      />),
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.IRONFUR.id} />}
-        value={`${formatPercentage(totalIronFurTime/fightDuration)}%`}
-        label='Total Ironfur uptime'
-      />,
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.THRASH_BEAR.id} />}
-        value={`${formatPercentage(thrashUptimePercentage)}%`}
-        label='Thrash uptime'
-      />,
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.MOONFIRE_BEAR.id} />}
-        value={`${formatPercentage(moonfireUptimePercentage)}%`}
-        label='Moonfire uptime'
-      />,
-
-      this.selectedCombatant.hasTalent(SPELLS.PULVERIZE_TALENT.id) && (<StatisticBox
-        icon={<SpellIcon id={SPELLS.PULVERIZE_TALENT.id} />}
-        value={`${formatPercentage(pulverizeUptimePercentage)}%`}
-        label='Pulverize uptime'
-      />),
-  ];
-
-    // TODO: Items
-
     results.tabs = [
       {
         title: 'Suggestions',

--- a/src/Parser/GuardianDruid/CombatLogParser.js
+++ b/src/Parser/GuardianDruid/CombatLogParser.js
@@ -46,18 +46,6 @@ class CombatLogParser extends MainCombatLogParser {
     dualDetermination: DualDetermination,
   };
 
-  damageBySchool = {};
-  totalOverkill = 0;
-  on_toPlayer_damage(event) {
-    if (this.damageBySchool[event.ability.type] === undefined) {
-      this.damageBySchool[event.ability.type] = 0;
-    }
-    this.damageBySchool[event.ability.type] += event.amount + (event.absorbed || 0) + (event.overkill || 0);
-    // Unsure at this point if this should be added to the super class total, keeping seperate for now...
-    this.totalOverkill += event.overkill || 0;
-    super.on_toPlayer_damage(event);
-  }
-
   generateResults() {
     const results = super.generateResults();
     results.tabs = [

--- a/src/Parser/GuardianDruid/Modules/Core/DamageDone.js
+++ b/src/Parser/GuardianDruid/Modules/Core/DamageDone.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { formatThousands, formatNumber } from 'common/format';
+import Module from 'Parser/Core/Module';
+import Icon from 'common/Icon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class DamageDone extends Module {
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<Icon icon="class_druid" alt="Damage done" />}
+        value={`${formatNumber(this.owner.totalDamageDone / this.owner.fightDuration * 1000)} DPS`}
+        label='Damage done'
+        tooltip={`The total damage done was ${formatThousands(this.owner.totalDamageDone)}.`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(4);
+}
+
+export default DamageDone;

--- a/src/Parser/GuardianDruid/Modules/Core/DamageTaken.js
+++ b/src/Parser/GuardianDruid/Modules/Core/DamageTaken.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { formatThousands, formatNumber, formatPercentage } from 'common/format';
+import Module from 'Parser/Core/Module';
+import Icon from 'common/Icon';
+import { getMagicDescription } from 'common/DamageTypes';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class DamageTaken extends Module {
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<Icon icon="class_druid" alt="Damage taken" />}
+        value={`${formatNumber((this.owner.totalDamageTaken + this.owner.totalOverkill) / this.owner.fightDuration * 1000)} DTPS`}
+        label='Damage taken'
+        tooltip={`Damage taken breakdown:
+            <ul>
+              ${Object.keys(this.owner.damageBySchool).reduce((v, x) => {return v+=`<li>${getMagicDescription(x)} damage taken ${formatThousands(this.owner.damageBySchool[x])} (${formatPercentage(this.owner.damageBySchool[x]/this.owner.totalDamageTaken)}%)</li>`; }, '')}
+            </ul>
+            Total damage taken ${formatThousands(this.owner.totalDamageTaken + this.owner.totalOverkill)} (${formatThousands(this.owner.totalOverkill)} overkill)`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(0);
+}
+
+export default DamageTaken;

--- a/src/Parser/GuardianDruid/Modules/Core/DamageTaken.js
+++ b/src/Parser/GuardianDruid/Modules/Core/DamageTaken.js
@@ -1,22 +1,23 @@
 import React from 'react';
 import { formatThousands, formatNumber, formatPercentage } from 'common/format';
-import Module from 'Parser/Core/Module';
+import MainDamageTaken from 'Parser/Core/Modules/DamageTaken';
 import Icon from 'common/Icon';
-import { getMagicDescription } from 'common/DamageTypes';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
-class DamageTaken extends Module {
+class DamageTaken extends MainDamageTaken {
   statistic() {
     return (
       <StatisticBox
         icon={<Icon icon="class_druid" alt="Damage taken" />}
-        value={`${formatNumber((this.owner.totalDamageTaken + this.owner.totalOverkill) / this.owner.fightDuration * 1000)} DTPS`}
+        value={`${formatNumber(this.TotalDamage.Total / this.owner.fightDuration * 1000)} DTPS`}
         label='Damage taken'
         tooltip={`Damage taken breakdown:
             <ul>
-              ${Object.keys(this.owner.damageBySchool).reduce((v, x) => {return v+=`<li>${getMagicDescription(x)} damage taken ${formatThousands(this.owner.damageBySchool[x])} (${formatPercentage(this.owner.damageBySchool[x]/this.owner.totalDamageTaken)}%)</li>`; }, '')}
+              ${Object.keys(this.DamageBySchool).reduce((v, type) => {
+                return v+=`<li>${type} damage taken ${formatThousands(this.DamageBySchool[type].Total)} (${formatPercentage(this.DamageBySchool[type].Total/this.TotalDamage.Total)}%)</li>`; 
+              }, '')}
             </ul>
-            Total damage taken ${formatThousands(this.owner.totalDamageTaken + this.owner.totalOverkill)} (${formatThousands(this.owner.totalOverkill)} overkill)`}
+            Total damage taken ${formatThousands(this.TotalDamage.Total)} (${formatThousands(this.TotalDamage.Overkill)} overkill)`}
       />
     );
   }

--- a/src/Parser/GuardianDruid/Modules/Core/HealingDone.js
+++ b/src/Parser/GuardianDruid/Modules/Core/HealingDone.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { formatThousands, formatNumber } from 'common/format';
+import Module from 'Parser/Core/Module';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class HealingDone extends Module {
+  statistic() {
+    return (
+      <StatisticBox
+        icon={(
+          <img
+            src="/img/healing.png"
+            style={{ border: 0 }}
+            alt="Healing"
+          />
+        )}
+        value={`${formatNumber(this.owner.totalHealing / this.owner.fightDuration * 1000)} HPS`}
+        label="Healing done"
+        tooltip={`The total healing done recorded was ${formatThousands(this.owner.totalHealing)}.`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(1);
+}
+
+export default HealingDone;

--- a/src/Parser/GuardianDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/GuardianDruid/Modules/Features/AlwaysBeCasting.js
@@ -1,6 +1,9 @@
-import SPELLS from 'common/SPELLS';
-
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
+import SPELLS from 'common/SPELLS';
+import Icon from 'common/Icon';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
   static ABILITIES_ON_GCD = [
@@ -25,6 +28,33 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     SPELLS.MASS_ENTANGLEMENT_TALENT.id,
     SPELLS.WILD_CHARGE_TALENT.id,
   ];
+
+  suggestions(when) {
+    const deadTimePercentage = this.owner.modules.alwaysBeCasting.totalTimeWasted / this.owner.fightDuration;
+    
+    when(deadTimePercentage).isGreaterThan(0.2)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span> Your dead GCD time can be improved. Try to Always Be Casting (ABC)..</span>)
+          .icon('spell_mage_altertime')
+          .actual(`${formatPercentage(deadTimePercentage)}% dead GCD time`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% is recommended`)
+          .regular(recommended + 0.05).major(recommended + 0.15);
+      });
+  }
+
+  statistic() {
+    const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
+   
+    return (
+      <StatisticBox
+        icon={<Icon icon="spell_mage_altertime" alt="Dead GCD time" />}
+        value={`${formatPercentage(deadTimePercentage)} %`}
+        label='Dead GCD time'
+        tooltip='Dead GCD time is available casting time not used. This can be caused by latency, cast interrupting, not casting anything (e.g. due to movement/stunned), etc.'
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(2);
 }
 
 export default AlwaysBeCasting;

--- a/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
@@ -5,7 +5,7 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
 import GuardianOfElune from './GuardianOfElune';
 
-class IronFurGoEProcs extends GuardianOfElune {
+class FrenziedRegenGoEProcs extends GuardianOfElune {
   statistic() {
     return (
       this.active && (<StatisticBox
@@ -19,4 +19,4 @@ class IronFurGoEProcs extends GuardianOfElune {
   statisticOrder = STATISTIC_ORDER.CORE(8);
 }
   
-export default IronFurGoEProcs;
+export default FrenziedRegenGoEProcs;

--- a/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
@@ -3,16 +3,18 @@ import { formatPercentage } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
-import GuardianOfElune from './GuardianOfElune';
+import Module from 'Parser/Core/Module';
 
-class FrenziedRegenGoEProcs extends GuardianOfElune {
+class FrenziedRegenGoEProcs extends Module {
   statistic() {
+    const nonGoEFRegen = this.owner.modules.guardianOfEluneProcs.nonGoEIronFur;
+    const GoEFRegen = this.owner.modules.guardianOfEluneProcs.GoEIronFur;
     return (
       this.active && (<StatisticBox
         icon={<SpellIcon id={SPELLS.FRENZIED_REGENERATION.id} />}
-        value={`${formatPercentage(this.nonGoEFRegen/(this.nonGoEFRegen + this.GoEFRegen))}%`}
+        value={`${formatPercentage(nonGoEFRegen/(nonGoEFRegen + GoEFRegen))}%`}
         label='Unbuffed Frenzied Regen'
-        tooltip={`You cast <b>${this.nonGoEFRegen + this.Regen}</b> total ${SPELLS.FRENZIED_REGENERATION.name} and <b> ${this.GoEFRegen} were buffed by 25%</b>.`}
+        tooltip={`You cast <b>${nonGoEFRegen + GoEFRegen}</b> total ${SPELLS.FRENZIED_REGENERATION.name} and <b> ${GoEFRegen}</b> were buffed by 20%.`}
       />)
     );
   }

--- a/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SPELLS from 'common/SPELLS';
+import GuardianOfElune from './GuardianOfElune';
+
+class IronFurGoEProcs extends GuardianOfElune {
+  statistic() {
+    return (
+      this.active && (<StatisticBox
+        icon={<SpellIcon id={SPELLS.FRENZIED_REGENERATION.id} />}
+        value={`${formatPercentage(this.nonGoEFRegen/(this.nonGoEFRegen + this.GoEFRegen))}%`}
+        label='Unbuffed Frenzied Regen'
+        tooltip={`You cast <b>${this.nonGoEFRegen + this.Regen}</b> total ${SPELLS.FRENZIED_REGENERATION.name} and <b> ${this.GoEFRegen} were buffed by 25%</b>.`}
+      />)
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(8);
+}
+  
+export default IronFurGoEProcs;

--- a/src/Parser/GuardianDruid/Modules/Features/GalacticGuardian.js
+++ b/src/Parser/GuardianDruid/Modules/Features/GalacticGuardian.js
@@ -1,5 +1,8 @@
-// Based on Clearcasting Implementation done by @Blazyb
-
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
 import SPELLS from 'common/SPELLS';
 
@@ -60,6 +63,34 @@ class GalacticGuardian extends Module {
       }
     }
   }
+
+  suggestions(when) {
+    const unusedGGProcs = 1 - (this.consumedGGProc / this.GGProcsTotal);
+    
+    this.active &&
+    when(unusedGGProcs).isGreaterThan(0.3)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your <SpellLink id={SPELLS.GALACTIC_GUARDIAN.id} /> procs should be used as soon as you get them so they are not overwritten.</span>)
+          .icon(SPELLS.GALACTIC_GUARDIAN.icon)
+          .actual(`${formatPercentage(unusedGGProcs)}% unused`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% or less is recommended`)
+          .regular(recommended + 0.15).major(recommended + 0.3);
+      });
+  }
+
+  statistic() {
+    const unusedGGProcs = 1 - (this.consumedGGProc / this.GGProcsTotal);
+    
+    return (
+      this.active && (<StatisticBox
+        icon={<SpellIcon id={SPELLS.GALACTIC_GUARDIAN.id} />}
+        value={`${formatPercentage(unusedGGProcs)}%`}
+        label='Unused Galactic Guardian'
+        tooltip={`You got total <b>${this.GGProcsTotal}</b> galactic guardian procs and <b>used ${this.consumedGGProc}</b> of them.`}
+      />)
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(6);
 }
 
 export default GalacticGuardian;

--- a/src/Parser/GuardianDruid/Modules/Features/Gore.js
+++ b/src/Parser/GuardianDruid/Modules/Features/Gore.js
@@ -1,5 +1,9 @@
 // Based on Clearcasting Implementation done by @Blazyb
-
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
 import SPELLS from 'common/SPELLS';
 
@@ -54,6 +58,33 @@ class Gore extends Module {
       }
     }
   }
+
+  suggestions(when) {
+    const unusedGoreProcs = 1 - (this.consumedGoreProc / this.GoreProcsTotal);
+    
+    when(unusedGoreProcs).isGreaterThan(0.3)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your <SpellLink id={SPELLS.GORE_BEAR.id} /> procs should be used as soon as you get them so they are not overwritten.</span>)
+          .icon(SPELLS.GORE_BEAR.icon)
+          .actual(`${formatPercentage(unusedGoreProcs)}% unused`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% or less is recommended`)
+          .regular(recommended + 0.15).major(recommended + 0.3);
+      });
+  }
+
+  statistic() {
+    const unusedGoreProcs = 1 - (this.consumedGoreProc / this.GoreProcsTotal);
+   
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.GORE_BEAR.id} />}
+        value={`${formatPercentage(unusedGoreProcs)}%`}
+        label='Unused Gore Procs'
+        tooltip={`You got total <b>${this.GoreProcsTotal}</b> gore procs and <b>used ${this.consumedGoreProc}</b> of them.`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
 }
 
 export default Gore;

--- a/src/Parser/GuardianDruid/Modules/Features/GuardianOfElune.js
+++ b/src/Parser/GuardianDruid/Modules/Features/GuardianOfElune.js
@@ -1,5 +1,8 @@
-// Based on Clearcasting Implementation done by @Blazyb
-
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
 import SPELLS from 'common/SPELLS';
 
@@ -85,6 +88,34 @@ class GuardianOfElune extends Module {
       }
     }
   }
+
+  suggestions(when) {
+    const unusedGoEProcs = 1 - (this.consumedGoEProc / this.GoEProcsTotal);
+    
+    this.active &&
+    when(unusedGoEProcs).isGreaterThan(0.3)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your <SpellLink id={SPELLS.GUARDIAN_OF_ELUNE.id} /> procs should be used as soon as you get them so they are not overwritten.</span>)
+          .icon(SPELLS.GUARDIAN_OF_ELUNE.icon)
+          .actual(`${formatPercentage(unusedGoEProcs)}% unused`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% or less is recommended`)
+          .regular(recommended + 0.15).major(recommended + 0.3);
+      });
+  }
+
+  statistic() {
+    const unusedGoEProcs = 1 - (this.consumedGoEProc / this.GoEProcsTotal);
+    
+    return (
+      this.active && (<StatisticBox
+        icon={<SpellIcon id={SPELLS.GUARDIAN_OF_ELUNE.id} />}
+        value={`${formatPercentage(unusedGoEProcs)}%`}
+        label='Unused Guardian of Elune'
+        tooltip={`You got total <b>${this.GoEProcsTotal}</b> guardian of elune procs and <b>used ${this.consumedGoEProc}</b> of them.`}
+      />)
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(7);
 }
 
 export default GuardianOfElune;

--- a/src/Parser/GuardianDruid/Modules/Features/IronFurGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/IronFurGoEProcs.js
@@ -3,16 +3,18 @@ import { formatPercentage } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
-import GuardianOfElune from './GuardianOfElune';
+import Module from 'Parser/Core/Module';
 
-class IronFurGoEProcs extends GuardianOfElune {
+class IronFurGoEProcs extends Module {
   statistic() {
+    const nonGoEIronFur = this.owner.modules.guardianOfEluneProcs.nonGoEIronFur;
+    const GoEIronFur = this.owner.modules.guardianOfEluneProcs.GoEIronFur;
     return (
       this.active && (<StatisticBox
         icon={<SpellIcon id={SPELLS.IRONFUR.id} />}
-        value={`${formatPercentage(this.nonGoEIronFur/(this.nonGoEIronFur + this.GoEIronFur))}%`}
+        value={`${formatPercentage(nonGoEIronFur/(nonGoEIronFur + GoEIronFur))}%`}
         label='Unbuffed Ironfur'
-        tooltip={`You cast <b>${this.nonGoEIronFur + this.GoEIronFur}</b> total ${SPELLS.IRONFUR.name} and <b> ${this.GoEIronFur} were buffed by 25%</b>.`}
+        tooltip={`You cast <b>${nonGoEIronFur + GoEIronFur}</b> total ${SPELLS.IRONFUR.name} and <b>${GoEIronFur}</b> were buffed by 2s.`}
       />)
     );
   }

--- a/src/Parser/GuardianDruid/Modules/Features/IronFurGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/IronFurGoEProcs.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SPELLS from 'common/SPELLS';
+import GuardianOfElune from './GuardianOfElune';
+
+class IronFurGoEProcs extends GuardianOfElune {
+  statistic() {
+    return (
+      this.active && (<StatisticBox
+        icon={<SpellIcon id={SPELLS.IRONFUR.id} />}
+        value={`${formatPercentage(this.nonGoEIronFur/(this.nonGoEIronFur + this.GoEIronFur))}%`}
+        label='Unbuffed Ironfur'
+        tooltip={`You cast <b>${this.nonGoEIronFur + this.GoEIronFur}</b> total ${SPELLS.IRONFUR.name} and <b> ${this.GoEIronFur} were buffed by 25%</b>.`}
+      />)
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(9);
+}
+  
+export default IronFurGoEProcs;

--- a/src/Parser/GuardianDruid/Modules/Spells/IronFur.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/IronFur.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Module from 'Parser/Core/Module';
+import SPELLS from 'common/SPELLS';
+
+class IronFur extends Module {
+  statistic() {
+    const totalIronFurTime = this.owner.selectedCombatant.getBuffUptime(SPELLS.IRONFUR.id);
+   
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.IRONFUR.id} />}
+        value={`${formatPercentage(totalIronFurTime/this.owner.fightDuration)}%`}
+        label='Total Ironfur uptime'
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(10);
+}
+  
+export default IronFur;

--- a/src/Parser/GuardianDruid/Modules/Spells/Moonfire.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/Moonfire.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Module from 'Parser/Core/Module';
+import SPELLS from 'common/SPELLS';
+
+class Moonfire extends Module {
+  suggestions(when) {
+    const moonfireUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.owner.fightDuration;
+
+    when(moonfireUptimePercentage).isLessThan(0.95)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span> Your <SpellLink id={SPELLS.MOONFIRE_BEAR.id} /> uptime should be near 100%, unless you have extended periods of downtime. Targets with Moonfire applied to them deal less damage to you due to <SpellLink id={SPELLS.SCINTILLATING_MOONLIGHT.id} />.</span>)
+          .icon(SPELLS.MOONFIRE_BEAR.icon)
+          .actual(`${formatPercentage(moonfireUptimePercentage)}% uptime`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% is recommended`)
+          .regular(recommended - 0.05).major(recommended - 0.15);
+      });
+  }
+
+  statistic() {
+    const moonfireUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.owner.fightDuration;
+    
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.MOONFIRE_BEAR.id} />}
+        value={`${formatPercentage(moonfireUptimePercentage)}%`}
+        label='Moonfire uptime'
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(12);
+}
+  
+export default Moonfire;

--- a/src/Parser/GuardianDruid/Modules/Spells/Pulverize.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/Pulverize.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Module from 'Parser/Core/Module';
+import SPELLS from 'common/SPELLS';
+
+class Pulverize extends Module {
+
+  suggestions(when) {
+    const pulverizeUptimePercentage = this.owner.selectedCombatant.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.owner.fightDuration;
+    
+    this.owner.selectedCombatant.hasTalent(SPELLS.PULVERIZE_TALENT.id) && 
+    when(pulverizeUptimePercentage).isLessThan(0.9)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span> Your <SpellLink id={SPELLS.PULVERIZE_TALENT.id} /> uptime should be near 100%, unless there are extended periods of downtime. All targets deal less damage to you due to the <SpellLink id={SPELLS.PULVERIZE_BUFF.id} /> buff.</span>)
+          .icon(SPELLS.PULVERIZE_TALENT.icon)
+          .actual(`${formatPercentage(pulverizeUptimePercentage)}% uptime`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% is recommended`)
+          .regular(recommended - 0.1).major(recommended - 0.2);
+      });
+  }
+
+  statistic() {
+    const pulverizeUptimePercentage = this.owner.selectedCombatant.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.owner.fightDuration;
+    
+    return (
+      this.owner.selectedCombatant.hasTalent(SPELLS.PULVERIZE_TALENT.id) && (<StatisticBox
+        icon={<SpellIcon id={SPELLS.PULVERIZE_TALENT.id} />}
+        value={`${formatPercentage(pulverizeUptimePercentage)}%`}
+        label='Pulverize uptime'
+      />)
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(13);
+}
+  
+export default Pulverize;

--- a/src/Parser/GuardianDruid/Modules/Spells/Thrash.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/Thrash.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Module from 'Parser/Core/Module';
+import SPELLS from 'common/SPELLS';
+
+class Thrash extends Module {
+
+  suggestions(when) {
+    const thrashUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.owner.fightDuration;
+    
+    when(thrashUptimePercentage).isLessThan(0.95)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span> Your <SpellLink id={SPELLS.THRASH_BEAR_DOT.id} /> uptime should be near 100%, unless you have extended periods of downtime. Thrash applies a bleed which buffs the damage of <SpellLink id={SPELLS.MANGLE_BEAR.id} /> by 20%.  Thrash uptime is especially important if you are talented into <SpellLink id={SPELLS.REND_AND_TEAR_TALENT.id} />, since it buffs the rest of your damage and gives you extra damage reduction.</span>)
+          .icon(SPELLS.THRASH_BEAR.icon)
+          .actual(`${formatPercentage(thrashUptimePercentage)}% uptime`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% is recommended`)
+          .regular(recommended - 0.05).major(recommended - 0.15);
+      });
+  }
+
+  statistic() {
+    const thrashUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.owner.fightDuration;
+   
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.THRASH_BEAR.id} />}
+        value={`${formatPercentage(thrashUptimePercentage)}%`}
+        label='Thrash uptime'
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(11);
+}
+  
+export default Thrash;

--- a/src/common/DamageTypes.js
+++ b/src/common/DamageTypes.js
@@ -1,0 +1,25 @@
+export const damageType = {
+  1: 'Physical',
+  2: 'Holy',
+  4: 'Fire',
+  8: 'Nature',
+  16: 'Frost',
+  28: 'Elemental',
+  32: 'Shadow',
+  33: 'Shadowstrike',
+  34: 'Twilight',
+  36: 'Shadowflame',
+  40: 'Plague',
+  48: 'Shadowfrost',
+  64: 'Arcane',
+  96: 'Spellshadow',
+  100: 'Special',
+  124: 'Chaos',
+};
+
+export function getMagicDescription(type) {
+  if (damageType[type] === undefined) {
+    return 'Chaos';
+  }
+  return damageType[type];
+}


### PR DESCRIPTION
Mostly moving all the guardian druid into modules, also added overkill to damage taken (when you die the logs include it).

No new functionality, but it fixes the sorting of the statistics.