### PR TITLE
Move resource types into common and add all known types

### DIFF
--- a/src/Parser/Core/Modules/Items/PrePotion.js
+++ b/src/Parser/Core/Modules/Items/PrePotion.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 import ItemLink from 'common/ItemLink';
 
 import Module from 'Parser/Core/Module';
@@ -29,8 +30,6 @@ const SECOND_POTIONS = [
 const DURATION = 30000;
 const DURATION_PROLONGED = 60000;
 const ANCIENT_MANA_POTION_AMOUNT = 152000;
-
-const MANA_CLASS_RESOURCE_ID = 0;
 
 class PrePotion extends Module {
   usedPrePotion = false;
@@ -60,8 +59,7 @@ class PrePotion extends Module {
       this.usedSecondPotion = true;
     }
 
-    // class resource type 0 means the resource is mana
-    if (event.classResources && event.classResources[0] && event.classResources[0].type === MANA_CLASS_RESOURCE_ID) {
+    if (event.classResources && event.classResources[0] && event.classResources[0].type === RESOURCE_TYPES.MANA) {
       const resource = event.classResources[0];
       const manaLeftAfterCast = resource.amount - resource.cost;
       if (manaLeftAfterCast < ANCIENT_MANA_POTION_AMOUNT) {

--- a/src/Parser/Core/Modules/ManaValues.js
+++ b/src/Parser/Core/Modules/ManaValues.js
@@ -1,8 +1,7 @@
 import Module from 'Parser/Core/Module';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 
 const debug = false;
-
-const MANA_CLASS_RESOURCE_ID = 0;
 
 class ManaValue extends Module {
   lowestMana = 1100000;
@@ -13,7 +12,7 @@ class ManaValue extends Module {
     if(event.classResources) {
       debug && console.log('Current Ending Mana: ', this.endingMana);
       event.classResources.forEach(classResource => {
-        if (classResource.type === MANA_CLASS_RESOURCE_ID) {
+        if (classResource.type === RESOURCE_TYPES.MANA) {
           const manaValue = classResource.amount;
           const manaEvent = classResource.cost || 0;
           const currMana = manaValue - manaEvent;

--- a/src/Parser/Core/Modules/SpellManaCost.js
+++ b/src/Parser/Core/Modules/SpellManaCost.js
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
-import RESOURCE_TYPES from 'Parser/Core/RESOURCE_TYPES';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 
 class SpellManaCost extends Module {
   on_byPlayer_cast(event) {

--- a/src/Parser/Core/RESOURCE_TYPES.js
+++ b/src/Parser/Core/RESOURCE_TYPES.js
@@ -1,4 +1,0 @@
-const RESOURCE_TYPES = {
-  MANA: 0,
-};
-export default RESOURCE_TYPES;

--- a/src/common/RESOURCE_TYPES.js
+++ b/src/common/RESOURCE_TYPES.js
@@ -1,0 +1,21 @@
+export default {
+  MANA: 0,
+  RAGE: 1,
+  FOCUS: 2,
+  ENERGY: 3,
+  COMBO_POINTS: 4,
+  RUNES: 5,
+  RUNIC_POWER: 6,
+  SOUL_SHARDS: 7,
+  ASTRAL_POWER: 8,
+  HOLY_POWER: 9,
+  ALTERNATE_POWER: 10, // Used for encounter-specific resources like Torment on Demonic Inqusition
+  MAELSTROM: 11,
+  CHI: 12,
+  INSANITY: 13,
+  // 14 is obsolete
+  // 15 is obsolete
+  ARCANE_CHARGES: 16,
+  FURY: 17,
+  PAIN: 18,
+};


### PR DESCRIPTION
Keeping with the convention of having shared data and enums in `common/`, this PR adds `common/RESOURCE_TYPES` with the known type ids from [Wowpedia's PowerType listing](https://wow.gamepedia.com/PowerType).  

I also removed the old `Parser/Core/RESOURCE_TYPES` and migrated existing references to the new location.  There might be other places where resource types are hardcoded in class modules, but I'll leave that for the maintainers to update.