### PR TITLE
[Guardian] Rage waste statistic

### DIFF
--- a/src/Parser/GuardianDruid/CombatLogParser.js
+++ b/src/Parser/GuardianDruid/CombatLogParser.js
@@ -15,6 +15,7 @@ import GalacticGuardian from './Modules/Features/GalacticGuardian';
 import GuardianOfElune from './Modules/Features/GuardianOfElune';
 import IronFurGoEProcs from './Modules/Features/IronFurGoEProcs';
 import FrenziedRegenGoEProcs from './Modules/Features/FrenziedRegenGoEProcs';
+import RageWasted from './Modules/Features/RageWasted';
 import IronFur from './Modules/Spells/IronFur';
 import Thrash from './Modules/Spells/Thrash';
 import Moonfire from './Modules/Spells/Moonfire';
@@ -38,6 +39,7 @@ class CombatLogParser extends MainCombatLogParser {
     guardianOfEluneProcs: GuardianOfElune,
     ironFurGoEProcs: IronFurGoEProcs,
     frenziedRegenGoEProcs: FrenziedRegenGoEProcs,
+    rageWasted: RageWasted,
     ironFur: IronFur,
     thrash: Thrash,
     moonfire: Moonfire,

--- a/src/Parser/GuardianDruid/Modules/Features/RageWasted.js
+++ b/src/Parser/GuardianDruid/Modules/Features/RageWasted.js
@@ -15,9 +15,6 @@ import Module from 'Parser/Core/Module';
 // field with each event, this shouldn't be a problem.
 const RAW_RAGE_GAINED_FROM_MELEE = 60;
 
-// The cost of a Gory Fur-reduced Ironfur, or the minimum amount of rage that can be spent
-const MINIMUM_ACCEPTABLE_RAGE_WASTE = 34;
-
 const RAGE_GENERATORS = {
   [SPELLS.MELEE.id]: 'Melee',
   [SPELLS.MANGLE_BEAR.id]: 'Mangle',

--- a/src/Parser/GuardianDruid/Modules/Features/RageWasted.js
+++ b/src/Parser/GuardianDruid/Modules/Features/RageWasted.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Module from 'Parser/Core/Module';
+
+// TODO: Sort wasted rage breakdown
+// TODO: Show overall rage gain in relation to wasted rage
+
+// NOTE: "Raw" rage is what shows up in combat log events (divided by 10 and rounded to get in-game rage).  We deal with raw rage here to prevent accuracy loss.
+
+// This is sometimes 59, for some bizarre reason.
+// As long as we re-sync with the classResources field on each
+// event this shouldn't be a problem.
+const RAW_RAGE_GAINED_FROM_MELEE = 60;
+
+// The cost of a Gory Fur-reduced Ironfur
+const MINIMUM_ACCEPTABLE_RAGE_WASTE = 34;
+
+const RAGE_GENERATORS = {
+  [SPELLS.MELEE.id]: 'Melee',
+  [SPELLS.MANGLE_BEAR.id]: 'Mangle',
+  [SPELLS.THRASH_BEAR.id]: 'Thrash',
+  [SPELLS.MOONFIRE.id]: 'Moonfire (Galactic Guardian)',
+  [SPELLS.BLOOD_FRENZY_TICK.id]: 'Blood Frenzy',
+  [SPELLS.BRISTLING_FUR.id]: 'Bristling Fur',
+}
+
+class RageWasted extends Module {
+  rageWastedBySpell = {};
+  currentRawRage = 0;
+
+  // Currently always 1000, but in case a future tier set/talent/artifact trait increases this it should "just work"
+  currentMaxRage = 0;
+
+  synchronizeRage(event) {
+    if (!event.classResources) {
+      console.log('no classResources', event);
+      return;
+    }
+    const rageResource = event.classResources.find(resource => resource.type === RESOURCE_TYPES.RAGE)
+    if (rageResource) {
+      this.currentRawRage = rageResource.amount;
+      this.currentMaxRage = rageResource.max;
+    }
+  }
+
+  registerRageWaste(abilityID, waste) {
+    if (!this.rageWastedBySpell[abilityID]) {
+      this.rageWastedBySpell[abilityID] = waste;
+    } else {
+      this.rageWastedBySpell[abilityID] += waste;
+    }
+  }
+
+  on_byPlayer_energize(event) {
+    this.synchronizeRage(event);
+    if (event.resourceChangeType !== RESOURCE_TYPES.RAGE) {
+      return;
+    }
+
+    if (event.waste > 0) {
+      this.registerRageWaste(event.ability.guid, event.waste);
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid === SPELLS.MELEE.id) {
+      if (this.currentRawRage + RAW_RAGE_GAINED_FROM_MELEE > this.currentMaxRage) {
+        const realRageWasted = Math.round((this.currentRawRage + RAW_RAGE_GAINED_FROM_MELEE - this.currentMaxRage) / 10);
+        this.registerRageWaste(event.ability.guid, realRageWasted);
+      }
+    }
+    this.synchronizeRage(event);
+  }
+
+  get totalWastedRage() {
+    return Object.values(this.rageWastedBySpell).reduce((total, waste) => total + waste, 0);
+  }
+
+  get wastedRageBreakdown() {
+    let str = 'Rage wasted per spell: <br />';
+
+    for (let spellID in this.rageWastedBySpell) {
+      if (this.rageWastedBySpell.hasOwnProperty(spellID)) {
+        const waste = this.rageWastedBySpell[spellID];
+        console.log('[rage waste]', spellID, waste);
+        str += `${RAGE_GENERATORS[spellID]}: ${waste}<br />`;
+      }
+    }
+    return str;
+  }
+
+  suggestions(when) {
+    when(this.totalWastedRage).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>You are wasting rage.  Try to spend rage before you reach the rage cap so you aren't losing out on potential <SpellLink id={SPELLS.IRONFUR.id} />s or <SpellLink id={SPELLS.MAUL.id} />s.</span>)
+          .icon(SPELLS.BRISTLING_FUR.icon)
+          .actual(`${actual} wasted rage`)
+          .recommended(`${recommended} is recommended`)
+          .regular(MINIMUM_ACCEPTABLE_RAGE_WASTE).major(MINIMUM_ACCEPTABLE_RAGE_WASTE * 2);
+      });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.BRISTLING_FUR.id} />}
+        label='Wasted Rage'
+        value={this.totalWastedRage}
+        tooltip={`
+          Rage gained that puts you over the rage cap is wasted.<br /><br />
+
+          ${this.wastedRageBreakdown}
+        `}
+      />
+    )
+  }
+}
+
+export default RageWasted;

--- a/src/common/ITEMS.js
+++ b/src/common/ITEMS.js
@@ -520,6 +520,12 @@ const ITEMS = {
     icon: 'inv_boots_mail_02',
     quality: ITEM_QUALITIES.LEGENDARY,
   },
+  OAKHEARTS_PUNY_QUODS: {
+    id: 144432,
+    name: 'Oakheart\'s Puny Quods',
+    icon: 'inv_helm_leather_raiddruid_m_01',
+    quality: ITEM_QUALITIES.LEGENDARY,
+  },
 
   // Vengeance Demon Hunter legendaries
   KIREL_NARAK: {

--- a/src/common/SPELLS_DRUID.js
+++ b/src/common/SPELLS_DRUID.js
@@ -456,4 +456,9 @@ export default {
     name: 'Bristling Fur',
     icon: 'spell_druid_bristlingfur',
   },
+  OAKHEARTS_PUNY_QUODS_BUFF: {
+    id: 236479,
+    name: 'Oakheart\'s Puny Quods',
+    icon: 'spell_druid_bearhug',
+  },
 };

--- a/src/common/SPELLS_DRUID.js
+++ b/src/common/SPELLS_DRUID.js
@@ -446,4 +446,14 @@ export default {
     name: 'Skysec\'s Hold',
     icon: 'spell_druid_bearhug',
   },
+  BLOOD_FRENZY_TICK: {
+    id: 203961,
+    name: 'Blood Frenzy',
+    icon: 'ability_druid_primaltenacity',
+  },
+  BRISTLING_FUR: {
+    id: 155835,
+    name: 'Bristling Fur',
+    icon: 'spell_druid_bristlingfur',
+  },
 };

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -55,6 +55,11 @@ export default {
 	  name: 'Spirit Berries',
 	  icon: 'inv_misc_food_93_skethylberries',
   },
+  PURE_RAGE_POTION: {
+    id: 175821,
+    name: 'Pure Rage Potion',
+    icon: 'trade_alchemy_dpotion_a13',
+  },
   // Items buffs:
   GNAWED_THUMB_RING: {
     id: 228461,

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -5,6 +5,11 @@
 
 export default {
   // General:
+  MELEE: {
+    id: 1,
+    name: 'Melee',
+    icon: 'inv_axe_02',
+  },
   LEECH: {
     id: 143924,
     name: 'Leech',


### PR DESCRIPTION
Displays wasted rage as a statistic and suggestion, including % of total rage gained that was wasted and a breakdown of waste by spell.