### PR TITLE
Changed logic for second pot suggestion for non-healers

### DIFF
--- a/src/Parser/Core/Modules/Items/PrePotion.js
+++ b/src/Parser/Core/Modules/Items/PrePotion.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS';
+import SPECS from 'common/SPECS';
 import ITEMS from 'common/ITEMS';
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 import ItemLink from 'common/ItemLink';
@@ -9,6 +10,15 @@ import Module from 'Parser/Core/Module';
 import SUGGESTION_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
 
 const debug = false;
+
+const HEALER_SPECS = [
+  SPECS.HOLY_PALADIN.id,
+  SPECS.RESTORATION_DRUID.id,
+  SPECS.HOLY_PRIEST.id,
+  SPECS.DISCIPLINE_PRIEST.id,
+  SPECS.MISTWEAVER_MONK.id,
+  SPECS.RESTORATION_SHAMAN.id,
+];
 
 const PRE_POTIONS = [
   SPELLS.POTION_OF_PROLONGED_POWER.id,
@@ -86,7 +96,14 @@ class PrePotion extends Module {
       .addSuggestion(suggest => {
         let suggestionText;
         let importance;
-        if (!this.neededManaSecondPotion) {
+        // Only healer specs would use a mana potion all other specs either don't use mana as a primary resource (such as bears)
+        // or have another method to regen mana, this fixes an issue with Guardian where they shift out of bear form and cast a 
+        // spell but mana is not their primary resource and should not use a mana potion.
+        const healerSpec = HEALER_SPECS.indexOf(this.owner.selectedCombatant.specId) !== -1;
+        if (!healerSpec) {
+          suggestionText = <span>You forgot to use a potion during combat. By using a potion during combat such as <ItemLink id={ITEMS.POTION_OF_PROLONGED_POWER.id} /> you the increasing dps and also suvivability against a boss.</span>;
+          importance = SUGGESTION_IMPORTANCE.MINOR;
+        } else if (!this.neededManaSecondPotion) {
           suggestionText = <span>You forgot to use a potion during combat. Using a potion during combat allows you the benefit of either increasing output through <ItemLink id={ITEMS.POTION_OF_PROLONGED_POWER.id} /> or allowing you to gain mana using <ItemLink id={ITEMS.ANCIENT_MANA_POTION.id}/>, for example.</span>;
           importance = SUGGESTION_IMPORTANCE.MINOR;
         } else {


### PR DESCRIPTION
Currently if a non-healer that has mana as a resource, especially something like a bear who has a minimal amount of mana. If they go below the value of a mana potion it is suggested that they use a mana pot.

This should probably be done differently in a module, but this fixes the issues