### PR TITLE
[Guardian] Account for Guttural Roars talent when getting Stampeding Roar cd

### DIFF
--- a/src/Parser/GuardianDruid/Modules/Features/CastEfficiency.js
+++ b/src/Parser/GuardianDruid/Modules/Features/CastEfficiency.js
@@ -130,7 +130,7 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.STAMPEDING_ROAR_BEAR,
       category: CastEfficiency.SPELL_CATEGORIES.UTILITY,
-      getCooldown: haste => 120,
+      getCooldown: (haste, combatant) => (combatant.hasTalent(SPELLS.GUTTURAL_ROARS_TALENT.id) ? 60 : 120),
       noSuggestion: true,
     },
     {


### PR DESCRIPTION
Fixes Cast Efficiency bug where it shows SR being cast more than the max potential casts