### PR TITLE
[Guardian] Ownership change and changelog updates

### DIFF
--- a/src/Parser/GuardianDruid/CHANGELOG.js
+++ b/src/Parser/GuardianDruid/CHANGELOG.js
@@ -1,6 +1,11 @@
 export default `
+29-08-2017 - Guardian Druid: Added Fury of Nature and Luffa Wrappings statistics. (by faide).
+29-08-2017 - Guardian Druid: Added Earthwarden metrics and suggestions. (by faide).
+28-08-2017 - Guardian Druid: Fixed Stampeding Roar cast efficiency to work with Guttural Roars. (by faide).
+23-08-2017 - Guardian Druid: Added rage waste statistic and suggestion. (by faide).
 22-08-2017 - Guardian Druid: Fixed issue with calculation of Frenzied Regenration by Guardian of Elune. (by wopr).
 22-08-2017 - Guardian Druid: Fix to Ironfur uptime suggestion (by wopr).
+19-08-2017 - Guardian Druid: Added Skysec's Hold statistic and suggestion. (by faide).
 19-08-2017 - Guardian Druid: Added detail on Ironfur usage.
 18-08-2017 - Guardian Druid: Updates to align with new module structure and added overkill into DTPS display.
 13-08-2017 - Guardian Druid: Added damage type into the tooltip of damage taken, added logic for Pulverize and minor fixes. (by wopr)

--- a/src/Parser/GuardianDruid/CONFIG.js
+++ b/src/Parser/GuardianDruid/CONFIG.js
@@ -5,7 +5,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   spec: SPECS.GUARDIAN_DRUID,
-  maintainer: '@WOPR',
+  maintainer: '@faide',
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };


### PR DESCRIPTION
As discussed the other day, I will be taking over maintenance of the Guardian module from WOPR so he can continue to focus on Brewmaster.  This patch updates the maintainer name in `CONFIG.js`.

Also adds most of my changes to the `CHANGELOG`, per @buimichael's request.