### PR TITLE
[Guardian] Frenzied Regeneration

### DIFF
--- a/src/Parser/GuardianDruid/CombatLogParser.js
+++ b/src/Parser/GuardianDruid/CombatLogParser.js
@@ -21,6 +21,7 @@ import Thrash from './Modules/Spells/Thrash';
 import Moonfire from './Modules/Spells/Moonfire';
 import Pulverize from './Modules/Spells/Pulverize';
 import Earthwarden from './Modules/Talents/Earthwarden';
+import FrenziedRegeneration from './Modules/Spells/FrenziedRegeneration';
 
 import DualDetermination from './Modules/Items/DualDetermination';
 import SkysecsHold from './Modules/Items/Skysecs';
@@ -49,6 +50,7 @@ class CombatLogParser extends CoreCombatLogParser {
     thrash: Thrash,
     moonfire: Moonfire,
     pulverize: Pulverize,
+    frenziedRegeneration: FrenziedRegeneration,
 
     // Talents:
     earthwarden: Earthwarden,

--- a/src/Parser/GuardianDruid/Modules/Spells/FrenziedRegeneration.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/FrenziedRegeneration.js
@@ -1,4 +1,8 @@
+import React from 'react';
+
 import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+import SpellLink from 'common/SpellLink';
 
 import Module from 'Parser/Core/Module';
 
@@ -6,15 +10,23 @@ const WILDFLESH_MODIFIER_PER_RANK = 0.05;
 const FR_WINDOW_MS = 5000;
 const FR_MINIMUM_HP_HEAL = 0.05;
 
+const HEAL_THRESHOLD = 0.2;
+const HP_THRESHOLD = 0.7;
+
 class FrenziedRegeneration extends Module {
-  percentHPsAtCast = [];
-  percentHealsAtCast = [];
+  castData = [];
   damageEventsInWindow = [];
   _healModifier = 0.5;
+
+  // Charges are not used by this module, but they may be used in a future Death Recap module
   _charges = 2;
 
   get healModifier() {
     return this._healModifier;
+  }
+
+  get charges() {
+    return this._charges;
   }
 
   pruneDamageEvents(currentTimestamp) {
@@ -50,6 +62,7 @@ class FrenziedRegeneration extends Module {
       this.pruneDamageEvents(event.timestamp);
       const damageTakenInWindow = this.damageEventsInWindow.reduce((total, event) => total + event.damage, 0);
 
+      // TODO: is event ordering consistent here? (this cast event needs to happen before GoE removebuff)
       const goeModifier = this.owner.selectedCombatant.hasBuff(SPELLS.GUARDIAN_OF_ELUNE.id) ? 1.2 : 1;
 
       const healAmount = damageTakenInWindow * this.healModifier * goeModifier;
@@ -59,8 +72,11 @@ class FrenziedRegeneration extends Module {
         percentHeal = healAsPercentHP;
       }
 
-      this.percentHPsAtCast.push(percentHP);
-      this.percentHealsAtCast.push(percentHeal);
+      this.castData.push({
+        percentHP,
+        percentHeal,
+        actualHeal: healAmount,
+      });
     }
   }
 
@@ -71,9 +87,28 @@ class FrenziedRegeneration extends Module {
     });
   }
 
-  on_finished() {
-    console.log(this.percentHPsAtCast);
-    console.log(this.percentHealsAtCast);
+  // A cast is considered inefficient if the expected heal is less than 20% of max HP,
+  // and the target is above 70% HP at the time of the cast.
+  get inefficientCasts() {
+    return this.castData.filter(cast => (
+      cast.percentHeal <= HEAL_THRESHOLD &&
+      cast.percentHP >= HP_THRESHOLD
+    ));
+  }
+
+  suggestions(when) {
+    const inefficiency = this.inefficientCasts.length / this.castData.length;
+    when(inefficiency).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(
+          <span>You are casting <SpellLink id={SPELLS.FRENZIED_REGENERATION.id} /> inefficiently (at high HP and after low damage intake).  It is almost always better to wait until after you have taken a big hit to cast it, even if that means spending extended periods of time at maximum charges.  If you don't already have one, consider getting an FR prediction weakaura to assist you in casting it more effectively.</span>
+        )
+          .icon(SPELLS.FRENZIED_REGENERATION.icon)
+          .actual(`${formatPercentage(actual, 0)}% of casts had a predicted heal of less than ${formatPercentage(HEAL_THRESHOLD, 0)}% and were cast above ${formatPercentage(HP_THRESHOLD, 0)}% HP`)
+          .recommended(`${recommended}% is recommended`)
+          .regular(recommended + 0.05).major(recommended + 0.1);
+
+      });
   }
 }
 

--- a/src/Parser/GuardianDruid/Modules/Spells/FrenziedRegeneration.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/FrenziedRegeneration.js
@@ -1,0 +1,80 @@
+import SPELLS from 'common/SPELLS';
+
+import Module from 'Parser/Core/Module';
+
+const WILDFLESH_MODIFIER_PER_RANK = 0.05;
+const FR_WINDOW_MS = 5000;
+const FR_MINIMUM_HP_HEAL = 0.05;
+
+class FrenziedRegeneration extends Module {
+  percentHPsAtCast = [];
+  percentHealsAtCast = [];
+  damageEventsInWindow = [];
+  _healModifier = 0.5;
+  _charges = 2;
+
+  get healModifier() {
+    return this._healModifier;
+  }
+
+  pruneDamageEvents(currentTimestamp) {
+    // Remove old damage events that occurred outside the FR window
+    while (
+      this.damageEventsInWindow.length &&
+      this.damageEventsInWindow[0].timestamp + FR_WINDOW_MS < currentTimestamp
+    ) {
+      this.damageEventsInWindow.shift();
+    }
+  }
+
+  on_initialized() {
+    const player = this.owner.selectedCombatant;
+    const wildfleshRank = player.traitsBySpellId[SPELLS.WILDFLESH_TRAIT.id];
+    const fleshknittingRank = player.traitsBySpellId[SPELLS.FLESHKNITTING_TRAIT.id];
+    const versModifier = player.versatilityPercentage;
+
+    if (fleshknittingRank > 0) {
+      this._charges += 1;
+    }
+
+    this._healModifier += (wildfleshRank * WILDFLESH_MODIFIER_PER_RANK);
+    this._healModifier += versModifier;
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid === SPELLS.FRENZIED_REGENERATION.id) {
+      const percentHP = event.hitPoints / event.maxHitPoints;
+      // Minimum heal
+      let percentHeal = FR_MINIMUM_HP_HEAL;
+
+      this.pruneDamageEvents(event.timestamp);
+      const damageTakenInWindow = this.damageEventsInWindow.reduce((total, event) => total + event.damage, 0);
+
+      const goeModifier = this.owner.selectedCombatant.hasBuff(SPELLS.GUARDIAN_OF_ELUNE.id) ? 1.2 : 1;
+
+      const healAmount = damageTakenInWindow * this.healModifier * goeModifier;
+      const healAsPercentHP = healAmount / event.maxHitPoints;
+
+      if (healAsPercentHP > percentHeal) {
+        percentHeal = healAsPercentHP;
+      }
+
+      this.percentHPsAtCast.push(percentHP);
+      this.percentHealsAtCast.push(percentHeal);
+    }
+  }
+
+  on_toPlayer_damage(event) {
+    this.damageEventsInWindow.push({
+      timestamp: event.timestamp,
+      damage: event.amount + event.absorbed,
+    });
+  }
+
+  on_finished() {
+    console.log(this.percentHPsAtCast);
+    console.log(this.percentHealsAtCast);
+  }
+}
+
+export default FrenziedRegeneration;

--- a/src/common/SPELLS_DRUID.js
+++ b/src/common/SPELLS_DRUID.js
@@ -391,6 +391,16 @@ export default {
     name: 'Scintillating Moonlight',
     icon: 'spell_nature_starfall',
   },
+  WILDFLESH_TRAIT: {
+    id: 200400,
+    name: 'Wildflesh',
+    icon: 'ability_bullrush',
+  },
+  FLESHKNITTING_TRAIT: {
+    id: 238085,
+    name: 'Fleshknitting',
+    icon: 'ability_bullrush',
+  },
   GORE_BEAR: {
     id: 93622,
     name: 'Gore',


### PR DESCRIPTION
Adds a Frenzied Regeneration module that tracks FR use, and creates a suggestion when it is being used poorly.