### PR TITLE
[BrM] Fix to healing following the move to the module

### DIFF
--- a/src/Parser/BrewmasterMonk/Modules/Core/HealingDone.js
+++ b/src/Parser/BrewmasterMonk/Modules/Core/HealingDone.js
@@ -1,12 +1,24 @@
 import React from 'react';
 
 import { formatThousands, formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
 
 import CoreHealingDone from 'Parser/Core/Modules/HealingDone';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class HealingDone extends CoreHealingDone {
+  on_toPlayer_absorbed(event) {
+    // This is the same correction as damage taken for Brewmaster monks
+    // When stagger removes damage from an attack it is not a true heal but just delays the damage to be taken by a dot
+    // this needs to be subtrached from the damage taken but also the healing done.
+
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.STAGGER.id) {
+      this._subtractHealing(event.timestamp, 0, event.amount, 0);
+    }
+  }
+
   statistic() {
     return (
       <StatisticBox

--- a/src/Parser/Core/Modules/HealingDone.js
+++ b/src/Parser/Core/Modules/HealingDone.js
@@ -33,6 +33,9 @@ class HealingDone extends Module {
     const secondsIntoFight = Math.floor((timestamp - this.owner.fight.start_time) / 1000);
     this.bySecond[secondsIntoFight] = (this.bySecond[secondsIntoFight] || new HealingValue()).add(amount, absorbed, overheal);
   }
+  _subtractHealing(timestamp, amount = 0, absorbed = 0, overkill = 0) {
+    return this._addHealing(timestamp, -amount, -absorbed, -overkill);
+  }
 }
 
 export default HealingDone;

--- a/src/Parser/Core/Modules/HealingDone.js
+++ b/src/Parser/Core/Modules/HealingDone.js
@@ -33,8 +33,8 @@ class HealingDone extends Module {
     const secondsIntoFight = Math.floor((timestamp - this.owner.fight.start_time) / 1000);
     this.bySecond[secondsIntoFight] = (this.bySecond[secondsIntoFight] || new HealingValue()).add(amount, absorbed, overheal);
   }
-  _subtractHealing(timestamp, amount = 0, absorbed = 0, overkill = 0) {
-    return this._addHealing(timestamp, -amount, -absorbed, -overkill);
+  _subtractHealing(timestamp, amount = 0, absorbed = 0, overheal = 0) {
+    return this._addHealing(timestamp, -amount, -absorbed, -overheal);
   }
 }
 

--- a/src/tests/Parser/Brewmaster/HealingDone.test.js
+++ b/src/tests/Parser/Brewmaster/HealingDone.test.js
@@ -1,0 +1,64 @@
+import HealingDone from 'Parser/BrewmasterMonk/Modules/Core/HealingDone';
+import { processEvents } from './Fixtures/processEvents';
+import { SimpleFight, heal, absorbed, incomingDamage, staggerAbsorbed, staggerTicks } from './Fixtures/SimpleFight';
+
+// Uses the same test structure as damage taken with the healing object.
+// All stagger absorbs should be excluded
+describe('Brewmaster.DamageTaken', () => {
+  let healingDone;
+  beforeEach(() => {
+    healingDone = new HealingDone({
+      toPlayer: () => true,
+      byPlayer: () => true,
+      fight: { start_time: 0 },
+    });
+  });
+  it('healing done with no events', () => {
+    expect(healingDone.total.regular).toBe(0);
+    expect(healingDone.total.absorbed).toBe(0);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done with only healing events', () => {
+    processEvents(heal, healingDone);
+    expect(healingDone.total.regular).toBe(10);
+    expect(healingDone.total.absorbed).toBe(0);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done with only non-stagger absorbs', () => {
+    processEvents(absorbed, healingDone);
+    expect(healingDone.total.regular).toBe(0);
+    expect(healingDone.total.absorbed).toBe(16);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done with only stagger absorbs', () => {
+    processEvents(staggerAbsorbed, healingDone);
+    // Net should be zero
+    expect(healingDone.total.regular).toBe(0);
+    expect(healingDone.total.absorbed).toBe(0);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done with only boss damage', () => {
+    processEvents(incomingDamage, healingDone);
+    expect(healingDone.total.regular).toBe(0);
+    expect(healingDone.total.absorbed).toBe(0);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done with boss damage and stagger absorbs', () => {
+    processEvents([...incomingDamage, ...staggerAbsorbed], healingDone);
+    expect(healingDone.total.regular).toBe(0);
+    expect(healingDone.total.absorbed).toBe(0);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done with only stagger dot', () => {
+    processEvents(staggerTicks, healingDone);
+    expect(healingDone.total.regular).toBe(0);
+    expect(healingDone.total.absorbed).toBe(0);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+  it('healing done taken for the fight', () => {
+    processEvents(SimpleFight, healingDone);
+    expect(healingDone.total.regular).toBe(10);
+    expect(healingDone.total.absorbed).toBe(16);
+    expect(healingDone.total.overheal).toBe(0);
+  });
+});


### PR DESCRIPTION
I didn't validate the move to modules correctly for healing on stagger.

The stagger absorb is neither healing or damage taken it is deferred to the stagger dot to either be taken later or purged (purifying brew/T20 4pc/End of fight/External Absorb).

Also added unit tests on the SimpleFight fixture following the same scenarios as the damage taken with values corrected for healing. Only true heals and non-stagger absorb (Dark Side of the Moon) should show.