### PR TITLE
(HPriest) Removing various this.owner calls

### DIFF
--- a/src/Parser/HolyPriest/Modules/Core/SpellManaCost.js
+++ b/src/Parser/HolyPriest/Modules/Core/SpellManaCost.js
@@ -1,12 +1,18 @@
 import SPELLS from 'common/SPELLS';
-
 import CoreSpellManaCost from 'Parser/Core/Modules/SpellManaCost';
+
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 import { ABILITIES_AFFECTED_BY_APOTHEOSIS_TALENT } from './../../Constants';
 
 const debug = false;
 
 class SpellManaCost extends CoreSpellManaCost {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   getManaCost(event) {
     const spellId = event.ability.guid;
     let cost = super.getManaCost(event);
@@ -15,7 +21,7 @@ class SpellManaCost extends CoreSpellManaCost {
     }
 
     // Apotheosis talent reduces the mana cost of Holy Word spells by 100%
-    if (this.owner.selectedCombatant.hasBuff(SPELLS.APOTHEOSIS_TALENT.id, event.timestamp)) {
+    if (this.combatants.selected.hasBuff(SPELLS.APOTHEOSIS_TALENT.id, event.timestamp)) {
       const isAbilityAffectedByApotheosis = ABILITIES_AFFECTED_BY_APOTHEOSIS_TALENT.indexOf(spellId) !== -1;
       if (isAbilityAffectedByApotheosis) {
         debug && console.log(SPELLS.APOTHEOSIS_TALENT.name, 'is active, reducing cost (', cost, ') by 100%');

--- a/src/Parser/HolyPriest/Modules/Items/TrousersOfAnjuna.js
+++ b/src/Parser/HolyPriest/Modules/Items/TrousersOfAnjuna.js
@@ -4,17 +4,23 @@ import { formatPercentage, formatNumber } from 'common/format';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import Module from 'Parser/Core/Module';
 
-
 class TrousersOfAnjuna extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   _validAfterByPlayer = {};
   healing = 0;
   overhealing = 0;
   absorbed = 0;
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasLegs(ITEMS.ENTRANCING_TROUSERS_OF_ANJUNA.id);
+    this.active = this.combatants.selected.hasLegs(ITEMS.ENTRANCING_TROUSERS_OF_ANJUNA.id);
   }
 
   on_byPlayer_removebuff(event) {

--- a/src/Parser/HolyPriest/Modules/Items/XanshiCloak.js
+++ b/src/Parser/HolyPriest/Modules/Items/XanshiCloak.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import { formatPercentage, formatNumber } from 'common/format';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 
 import Module from 'Parser/Core/Module';
 
-
 class XanshiCloak extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   _xanshiActive = false;
   healing = 0;
   overhealing = 0;
@@ -16,7 +22,7 @@ class XanshiCloak extends Module {
   casts = [];
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasBack(ITEMS.XANSHI_CLOAK.id);
+    this.active = this.combatants.selected.hasBack(ITEMS.XANSHI_CLOAK.id);
   }
 
   on_byPlayer_removebuff(event) {

--- a/src/Parser/HolyPriest/Modules/PriestCore/Divinity.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/Divinity.js
@@ -3,6 +3,9 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber, formatThousands } from 'common/format';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
 import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
@@ -12,10 +15,14 @@ import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../../Constants';
 const DIVINITY_HEALING_INCREASE = 0.15;
 
 class Divinity extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   healing = 0;
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.DIVINITY_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.DIVINITY_TALENT.id);
   }
 
   on_byPlayer_heal(event) {
@@ -32,7 +39,7 @@ class Divinity extends Module {
       return;
     }
 
-    if (!this.owner.selectedCombatant.hasBuff(SPELLS.DIVINITY_BUFF.id, event.timestamp)) {
+    if (!this.combatants.selected.hasBuff(SPELLS.DIVINITY_BUFF.id, event.timestamp)) {
       return;
     }
 
@@ -44,7 +51,7 @@ class Divinity extends Module {
     return this.active && (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.DIVINITY_TALENT.id} />}
-        value={`${((this.owner.selectedCombatant.getBuffUptime(SPELLS.DIVINITY_BUFF.id)/this.owner.fightDuration)*100).toFixed(1)} %`}
+        value={`${((this.combatants.selected.getBuffUptime(SPELLS.DIVINITY_BUFF.id)/this.owner.fightDuration)*100).toFixed(1)} %`}
         label={(
           <dfn data-tip={`The effective healing contributed by Divinity was ${formatThousands(this.healing)} / ${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))} % / ${formatNumber(this.healing / this.owner.fightDuration * 1000)} HPS.`}>
             Divinity uptime

--- a/src/Parser/HolyPriest/Modules/PriestCore/EnduringRenewal.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/EnduringRenewal.js
@@ -3,12 +3,19 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber } from 'common/format';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import Module from 'Parser/Core/Module';
 import { ABILITIES_THAT_TRIGGER_ENDURING_RENEWAL } from '../../Constants';
 
 class EnduringRenewal extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   _normalRenewDropoff = {};
   _newRenewDropoff = {};
   healing = 0;
@@ -24,8 +31,8 @@ class EnduringRenewal extends Module {
   // Enduring Renewal
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.ENDURING_RENEWAL_TALENT.id);
-    this._usingLegendaryLegs = this.owner.selectedCombatant.hasLegs(ITEMS.ENTRANCING_TROUSERS_OF_ANJUNA.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.ENDURING_RENEWAL_TALENT.id);
+    this._usingLegendaryLegs = this.combatants.selected.hasLegs(ITEMS.ENTRANCING_TROUSERS_OF_ANJUNA.id);
     this._baseRenewLength = 15 + (this._usingLegendaryLegs ? 6 : 0);
   }
 

--- a/src/Parser/HolyPriest/Modules/PriestCore/LightOfTuure.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/LightOfTuure.js
@@ -3,6 +3,9 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber } from 'common/format';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
 import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
@@ -10,14 +13,18 @@ import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../../Constants';
 
 class LightOfTuure extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   _lotTargets = {};
   buffHealing = 0;
   spellHealing = 0;
 
   on_initialized() {
-    this.lotTraits = this.owner.selectedCombatant.traitsBySpellId[SPELLS.CARESS_OF_THE_NAARU_TRAIT.id] || 0;
+    this.lotTraits = this.combatants.selected.traitsBySpellId[SPELLS.CARESS_OF_THE_NAARU_TRAIT.id] || 0;
     this.lotModifier = 0.25 + (0.05 * this.lotTraits);
-    this.active = this.owner.selectedCombatant.traitsBySpellId[SPELLS.LIGHT_OF_TUURE_TRAIT.id] > 0;
+    this.active = this.combatants.selected.traitsBySpellId[SPELLS.LIGHT_OF_TUURE_TRAIT.id] > 0;
   }
 
   on_byPlayer_applybuff(event) {

--- a/src/Parser/HolyPriest/Modules/PriestCore/RenewTheFaith.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/RenewTheFaith.js
@@ -1,20 +1,30 @@
 import React from 'react';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
+
 import { formatPercentage, formatNumber } from 'common/format';
 
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+import DivineHymn from '../Spells/DivineHymn';
+
 class RenewTheFaith extends Module {
+  static dependencies = {
+    combatants: Combatants,
+    divineHymn: DivineHymn,
+  }
+
   _validPoMBefore = 0;
   poms = 0;
   healing = 0;
   overhealing = 0;
 
   on_initialized() {
-    this._maxHymnDuration = 8 / (1 + this.owner.selectedCombatant.hastePercentage);
-    this.active = this.owner.selectedCombatant.traitsBySpellId[SPELLS.RENEW_THE_FAITH_TRAIT.id] > 0;
+    this._maxHymnDuration = 8 / (1 + this.combatants.selected.hastePercentage);
+    this.active = this.combatants.selected.traitsBySpellId[SPELLS.RENEW_THE_FAITH_TRAIT.id] > 0;
   }
 
   on_byPlayer_cast(event) {
@@ -37,7 +47,7 @@ class RenewTheFaith extends Module {
   statistic() {
     const rtfPercHPS = formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing));
     const rtfPercOH = formatPercentage(this.overhealing / (this.healing + this.overhealing));
-    const rtfRelPercHPS = formatPercentage(this.healing / this.owner.modules.divineHymn.healing);
+    const rtfRelPercHPS = formatPercentage(this.healing / this.divineHymn.healing);
 
     //
     return this.active && (

--- a/src/Parser/HolyPriest/Modules/Spells/PrayerOfMending.js
+++ b/src/Parser/HolyPriest/Modules/Spells/PrayerOfMending.js
@@ -3,10 +3,17 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber } from 'common/format';
 
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
 
 class PrayerOfMending extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
   _firstPoMCast = null;
   removed = 0;
   heals = 0;
@@ -44,7 +51,7 @@ class PrayerOfMending extends Module {
   }
 
   statistic() {
-    const sypTrait = this.owner.selectedCombatant.traitsBySpellId[SPELLS.SAY_YOUR_PRAYERS_TRAIT.id];
+    const sypTrait = this.combatants.selected.traitsBySpellId[SPELLS.SAY_YOUR_PRAYERS_TRAIT.id];
     const percPomIncFromSYP = ((1 + (sypTrait * SPELLS.SAY_YOUR_PRAYERS_TRAIT.coeff)) / (1 - (sypTrait * SPELLS.SAY_YOUR_PRAYERS_TRAIT.coeff))) - 1;
     const sypValue = this.healing * percPomIncFromSYP / (1 + percPomIncFromSYP);
     const sypHPS = sypValue / this.owner.fightDuration * 1000;


### PR DESCRIPTION
As discussed on Discord, `this.owner.selectedCombatant` and `this.owner.modules` are deprecated, so I've made such adjustments for the holy priest end here.