### PR TITLE
(Holy Priest) Echo of Light (aka Mastery) breakdown

### DIFF
--- a/src/Main/ExpandableStatisticBox.js
+++ b/src/Main/ExpandableStatisticBox.js
@@ -45,37 +45,39 @@ class ExpandableStatisticBox extends React.PureComponent {
 
   render() {
     return (
-      <div className="panel statistic-box expandable">
-        <div className="panel-body">
-          <div className="flex">
-            <div className="flex-sub">
-              {this.state.icon}
-            </div>
-            <div className="flex-main text-right">
-              <div className="value">
-                {this.state.value}
+      <div className="col-lg-4 col-sm-6 col-xs-12">
+        <div className="panel statistic-box expandable">
+          <div className="panel-body">
+            <div className="flex">
+              <div className="flex-sub">
+                {this.state.icon}
               </div>
-              <div className="slabel">
-                {this.state.label}
-              </div>
-            </div>
-          </div>
-
-          <div className="row">
-            <div className="col-xs-12">
-              {this.state.expanded && (
-                <div className="statistic-expansion">
-                  { this.props.children }
+              <div className="flex-main text-right">
+                <div className="value">
+                  {this.state.value}
                 </div>
-              )}
+                <div className="slabel">
+                  {this.state.label}
+                </div>
+              </div>
             </div>
-          </div>
 
-          <div className="statistic-expansion-button-holster">
-            <button onClick={this.toggleExpansion} className="btn btn-primary">
-              {!this.state.expanded && <span className="glyphicon glyphicon-chevron-down" />}
-              {this.state.expanded && <span className="glyphicon glyphicon-chevron-up" />}
-            </button>
+            <div className="row">
+              <div className="col-xs-12">
+                {this.state.expanded && (
+                  <div className="statistic-expansion">
+                    { this.props.children }
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="statistic-expansion-button-holster">
+              <button onClick={this.toggleExpansion} className="btn btn-primary">
+                {!this.state.expanded && <span className="glyphicon glyphicon-chevron-down" />}
+                {this.state.expanded && <span className="glyphicon glyphicon-chevron-up" />}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Parser/Core/Combatant.js
+++ b/src/Parser/Core/Combatant.js
@@ -78,6 +78,8 @@ class Combatant extends Entity {
     switch (this.spec) {
       case SPECS.HOLY_PALADIN:
         return 0.12 + this.masteryRating / 26667;
+      case SPECS.HOLY_PRIEST:
+        return 0.05 + this.masterRating / 32000;
       case SPECS.RESTORATION_SHAMAN:
         return 0.24 + this.masteryRating / 13333.3333333;
       case SPECS.ENHANCEMENT_SHAMAN:

--- a/src/Parser/Core/Combatant.js
+++ b/src/Parser/Core/Combatant.js
@@ -79,7 +79,7 @@ class Combatant extends Entity {
       case SPECS.HOLY_PALADIN:
         return 0.12 + this.masteryRating / 26667;
       case SPECS.HOLY_PRIEST:
-        return 0.05 + this.masterRating / 32000;
+        return 0.05 + this.masteryRating / 32000;
       case SPECS.RESTORATION_SHAMAN:
         return 0.24 + this.masteryRating / 13333.3333333;
       case SPECS.ENHANCEMENT_SHAMAN:

--- a/src/Parser/HolyPriest/CHANGELOG.js
+++ b/src/Parser/HolyPriest/CHANGELOG.js
@@ -1,9 +1,8 @@
 export default `
-22-07-2017 - Holy Priest: Added Holy Word: Sanctify efficiency metric and fixed an issue with Prayer of Mending cast efficiency (by enragednuke)
-05-07-2017 - Holy Priest: Added Enduring Renewal, Light of Tuure (incl. buff) and fixed a bug that greatly overvalued Divinity (by enragednuke)
-04-07-2017 - Holy Priest: Added Divinity talent. (by Skamer)
-02-07-2017 - Holy Priest: Apotheosis now correctly reduces the mana cost of Holy Word spells. Added Symbol of Hope talent. (by Skamer)
+03-09-2017 - Added Echo of Light (Mastery) breakdown (by enragednuke)
+22-07-2017 - Added Holy Word: Sanctify efficiency metric and fixed an issue with Prayer of Mending cast efficiency (by enragednuke)
+05-07-2017 - Added Enduring Renewal, Light of Tuure (incl. buff) and fixed a bug that greatly overvalued Divinity (by enragednuke)
+04-07-2017 - Added Divinity talent. (by Skamer)
+02-07-2017 - Apotheosis now correctly reduces the mana cost of Holy Word spells. Added Symbol of Hope talent. (by Skamer)
 01-07-2016 - Added <span class="Priest">Holy Priest</span> support by <b>@enragednuke</b>.
-
-
 `;

--- a/src/Parser/HolyPriest/CombatLogParser.js
+++ b/src/Parser/HolyPriest/CombatLogParser.js
@@ -28,6 +28,7 @@ import RenewTheFaith from './Modules/PriestCore/RenewTheFaith';
 import Divinity from './Modules/PriestCore/Divinity';
 import LightOfTuure from './Modules/PriestCore/LightOfTuure';
 import EnduringRenewal from './Modules/PriestCore/EnduringRenewal';
+import MasteryBreakdown from './Modules/PriestCore/MasteryBreakdown';
 
 // Items
 import TrousersOfAnjuna from './Modules/Items/TrousersOfAnjuna';
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     divinity: Divinity,
     lightOfTuure: LightOfTuure,
     enduringRenewal: EnduringRenewal,
+    MasteryBreakdown: MasteryBreakdown,
 
     // Spells
     prayerOfMending: PrayerOfMending,

--- a/src/Parser/HolyPriest/Constants.js
+++ b/src/Parser/HolyPriest/Constants.js
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 
 export const ABILITIES_AFFECTED_BY_HEALING_INCREASES = [
+  SPELLS.DIVINE_HYMN_HEAL.id,
   SPELLS.GREATER_HEAL.id,
   SPELLS.FLASH_HEAL.id,
   SPELLS.PRAYER_OF_MENDING_HEAL.id,
@@ -17,11 +18,13 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES = [
   SPELLS.HALO_HEAL.id,
   SPELLS.DIVINE_STAR_TALENT.id, // might have diff id for heal?
   SPELLS.OCEANS_EMBRACE,
+  SPELLS.GUILTY_CONSCIENCE.id,
 ];
 
 // better off making things that -dont- proc it perhaps?
 export const ABILITIES_THAT_TRIGGER_MASTERY = [
   // renew is not present due to the periodic ticking not proccing mastery
+  SPELLS.DIVINE_HYMN_HEAL.id,
   SPELLS.GREATER_HEAL.id,
   SPELLS.FLASH_HEAL.id,
   SPELLS.PRAYER_OF_MENDING_HEAL.id,
@@ -37,6 +40,7 @@ export const ABILITIES_THAT_TRIGGER_MASTERY = [
   SPELLS.HALO_HEAL.id,
   SPELLS.DIVINE_STAR_TALENT.id, // might have diff id for heal?
   SPELLS.OCEANS_EMBRACE.id,
+  SPELLS.GUILTY_CONSCIENCE.id,
 ];
 
 export const ABILITIES_THAT_TRIGGER_ENDURING_RENEWAL = [

--- a/src/Parser/HolyPriest/Constants.js
+++ b/src/Parser/HolyPriest/Constants.js
@@ -21,11 +21,11 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES = [
 
 // better off making things that -dont- proc it perhaps?
 export const ABILITIES_THAT_TRIGGER_MASTERY = [
+  // renew is not present due to the periodic ticking not proccing mastery
   SPELLS.GREATER_HEAL.id,
   SPELLS.FLASH_HEAL.id,
   SPELLS.PRAYER_OF_MENDING_HEAL.id,
   SPELLS.PRAYER_OF_HEALING.id,
-  SPELLS.RENEW.id,
   SPELLS.HOLY_WORD_SERENITY.id,
   SPELLS.HOLY_WORD_SANCTIFY.id,
   SPELLS.DESPERATE_PRAYER.id,
@@ -36,7 +36,7 @@ export const ABILITIES_THAT_TRIGGER_MASTERY = [
   SPELLS.CIRCLE_OF_HEALING_TALENT.id,
   SPELLS.HALO_HEAL.id,
   SPELLS.DIVINE_STAR_TALENT.id, // might have diff id for heal?
-  SPELLS.OCEANS_EMBRACE,
+  SPELLS.OCEANS_EMBRACE.id,
 ];
 
 export const ABILITIES_THAT_TRIGGER_ENDURING_RENEWAL = [

--- a/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
@@ -145,7 +145,7 @@ class MasteryBreakdown extends Module {
         icon={<SpellIcon id={SPELLS.ECHO_OF_LIGHT.id} />}
         value={`${formatNumber(this.healing)}`}
         label={(
-          <dfn data-tip={``}>
+          <dfn data-tip={`Echo of Light healing breakdown. As our mastery is often very finicky, this could end up wrong in various situations. Please report any logs that seem strange to @enragednuke on the WoWAnalyzer discord.`}>
             Echo of Light
           </dfn>
         )}

--- a/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
@@ -117,8 +117,6 @@ class MasteryBreakdown extends Module {
         return;
       }
 
-
-
       if(this._masteryActive[tId]) {
         this._tickMode[tId] = 3;
       } else {
@@ -167,7 +165,7 @@ class MasteryBreakdown extends Module {
               this.effectiveHealDistPerc
                 .map((item, index) => (
                   <tr key={index}>
-                    <th scope="row"><SpellLink id={item[0]} /></th>
+                    <th scope="row"><SpellIcon id={item[0]} style={{ height: '2.4em' }}/></th>
                     <td>{ formatNumber(this.healing * item[1]) }</td>
                     <td>{ formatPercentage(item[1]) }%</td>
                     <td>{ formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing) * item[1]) }%</td>

--- a/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import ExpandableStatisticBox from 'Main/ExpandableStatisticBox';
 import SpellIcon from 'common/SpellIcon';
-import SpellLink from 'common/SpellLink';
 import { formatPercentage, formatNumber } from 'common/format';
 
 // dependencies
@@ -14,7 +13,7 @@ import { ABILITIES_THAT_TRIGGER_MASTERY } from '../../Constants';
 
 class MasteryBreakdown extends Module {
   static dependencies = {
-    combatants: Combatants
+    combatants: Combatants,
   }
 
   _tickMode = {};
@@ -30,14 +29,14 @@ class MasteryBreakdown extends Module {
 
   on_finished() {
     // There's likely a far better way to do this, but my 2AM brain couldn't find it
-    var total = 0;
+    let total = 0;
 
-    var spell;
+    let spell;
     for (spell in this.effectiveHealDist) {
       total += this.effectiveHealDist[spell];
     }
 
-    var eHDPerc = {}
+    const eHDPerc = {};
     for (spell in this.effectiveHealDist) {
       eHDPerc[spell] = this.effectiveHealDist[spell] / total;
     }
@@ -45,7 +44,7 @@ class MasteryBreakdown extends Module {
     console.log(eHDPerc);
     // Since JS objects lack order, we need to convert our dictionary to an array
     // to allow for it be ordered for display
-    var eHDPArray = Object.keys(eHDPerc).map(function(spell) {
+    const eHDPArray = Object.keys(eHDPerc).map(function(spell) {
       return [spell, eHDPerc[spell]];
     });
     eHDPArray.sort(function(o1, o2) {
@@ -87,7 +86,7 @@ class MasteryBreakdown extends Module {
       const percOH = event.amount / (event.amount + (event.overheal || 0));
       const tickMode = this._tickMode[tId];
 
-      var spell;
+      let spell;
       for (spell in this._healVal[tId]) {
         this.effectiveHealDist = this.effectiveHealDist || {};
         this._eHDbyPlayer[tId] = this._eHDbyPlayer[tId] || {};

--- a/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
+++ b/src/Parser/HolyPriest/Modules/PriestCore/MasteryBreakdown.js
@@ -1,0 +1,186 @@
+import React from 'react';
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
+import ExpandableStatisticBox from 'Main/ExpandableStatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage, formatNumber } from 'common/format';
+
+// dependencies
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import Module from 'Parser/Core/Module';
+import { ABILITIES_THAT_TRIGGER_MASTERY } from '../../Constants';
+
+class MasteryBreakdown extends Module {
+  static dependencies = {
+    combatants: Combatants
+  }
+
+  _tickMode = {};
+  _healVal = {};
+  _maxHealVal = {};
+  _masteryActive = {};
+  effectiveHealDist = {};
+  _eHDbyPlayer = {}; // for potential future features
+
+  healing = 0;
+
+  effectiveHealDistPerc = [];
+
+  on_finished() {
+    // There's likely a far better way to do this, but my 2AM brain couldn't find it
+    var total = 0;
+
+    var spell;
+    for (spell in this.effectiveHealDist) {
+      total += this.effectiveHealDist[spell];
+    }
+
+    var eHDPerc = {}
+    for (spell in this.effectiveHealDist) {
+      eHDPerc[spell] = this.effectiveHealDist[spell] / total;
+    }
+
+    console.log(eHDPerc);
+    // Since JS objects lack order, we need to convert our dictionary to an array
+    // to allow for it be ordered for display
+    var eHDPArray = Object.keys(eHDPerc).map(function(spell) {
+      return [spell, eHDPerc[spell]];
+    });
+    eHDPArray.sort(function(o1, o2) {
+      return o2[1] - o1[1];
+    });
+
+    this.effectiveHealDistPerc = eHDPArray;
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    const tId = event.targetID;
+    if (spellId !== SPELLS.ECHO_OF_LIGHT.id) {
+      return;
+    }
+
+    this._masteryActive[tId] = true;
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    const tId = event.targetID;
+    if (spellId !== SPELLS.ECHO_OF_LIGHT.id) {
+      return;
+    }
+
+    this._masteryActive[tId] = false;
+    this._healVal[tId] = {};
+    this._maxHealVal[tId] = {};
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+    const tId = event.targetID;
+    if (spellId === SPELLS.ECHO_OF_LIGHT.id) {
+      // logic for eol itself
+      this.healing += event.amount;
+
+      const percOH = event.amount / (event.amount + (event.overheal || 0));
+      const tickMode = this._tickMode[tId];
+
+      var spell;
+      for (spell in this._healVal[tId]) {
+        this.effectiveHealDist = this.effectiveHealDist || {};
+        this._eHDbyPlayer[tId] = this._eHDbyPlayer[tId] || {};
+
+        // For potential future Features //
+        if (spell in this._eHDbyPlayer[tId]) {
+          this._eHDbyPlayer[tId][spell] += this._maxHealVal[tId][spell] * percOH / tickMode;
+        } else {
+          this._eHDbyPlayer[tId][spell] = this._maxHealVal[tId][spell] * percOH / tickMode;
+        }
+        // ----------------------------- //
+
+        //console.log(this._maxHealVal[tId]);
+        if (spell in this.effectiveHealDist) {
+          this.effectiveHealDist[spell] += this._maxHealVal[tId][spell] * percOH / tickMode;
+        } else {
+          this.effectiveHealDist[spell] = this._maxHealVal[tId][spell] * percOH / tickMode;
+        }
+
+        this._healVal[tId][spell] -= (this._maxHealVal[tId][spell] / tickMode);
+
+      }
+
+    } else {
+      // logic for eol triggering spells
+      if (ABILITIES_THAT_TRIGGER_MASTERY.indexOf(spellId) === -1) {
+        return;
+      }
+
+
+
+      if(this._masteryActive[tId]) {
+        this._tickMode[tId] = 3;
+      } else {
+        this._tickMode[tId] = 2;
+      }
+
+      if(!(tId in this._healVal)) {
+        this._healVal[tId] = {};
+      }
+
+      if(!(tId in this._maxHealVal)) {
+        this._maxHealVal[tId] = {};
+      }
+
+      if(!(spellId in this._healVal[tId])) {
+        this._healVal[tId][spellId] = event.amount;
+      } else {
+        this._healVal[tId][spellId] += event.amount;
+      }
+      this._maxHealVal[tId][spellId] = this._healVal[tId][spellId];
+    }
+  }
+
+  statistic() {
+    return (
+      <ExpandableStatisticBox
+        icon={<SpellIcon id={SPELLS.ECHO_OF_LIGHT.id} />}
+        value={`${formatNumber(this.healing)}`}
+        label={(
+          <dfn data-tip={``}>
+            Echo of Light
+          </dfn>
+        )}
+      >
+        <table className="table table-condensed">
+          <thead>
+            <tr>
+              <th>Spell</th>
+              <th>Amount</th>
+              <th>% of EoL</th>
+              <th>% of Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.effectiveHealDistPerc
+                .map((item, index) => (
+                  <tr key={index}>
+                    <th scope="row"><SpellLink id={item[0]} /></th>
+                    <td>{ formatNumber(this.healing * item[1]) }</td>
+                    <td>{ formatPercentage(item[1]) }%</td>
+                    <td>{ formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing) * item[1]) }%</td>
+                  </tr>
+                ))
+            }
+          </tbody>
+        </table>
+      </ExpandableStatisticBox>
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.CORE(2);
+}
+
+export default MasteryBreakdown;

--- a/src/common/SPELLS_PRIEST.js
+++ b/src/common/SPELLS_PRIEST.js
@@ -287,7 +287,7 @@ export default {
   PRAYER_OF_HEALING: {
     id: 596,
     name: 'Prayer of Healing',
-    icon: 'spell_holy_prayerofhealing',
+    icon: 'spell_holy_prayerofhealing02',
     manaCost: 49500,
   },
 
@@ -560,7 +560,7 @@ export default {
   },
 
 
-  
-  
+
+
 
 };


### PR DESCRIPTION
Finally got to writing the module for the Echo of Light breakdown. As this isn't something that is available through WCL, it's been highly requested in respect to other things.

Also fixes a bug with the Expandable Statistic Box that was causing it to span across multiple columns unexpectedly.

![image](https://media.giphy.com/media/26vIf1MS9YSV3FjuE/giphy.gif)

edit: the columns above look the same but the 3rd column is now % of total and the 4th is % overheal instead.
