### PR TITLE
[Resto Druid] Added T19 2pc module

### DIFF
--- a/src/Parser/RestoDruid/CombatLogParser.js
+++ b/src/Parser/RestoDruid/CombatLogParser.js
@@ -22,6 +22,7 @@ import DarkTitanAdvice from './Modules/Legendaries/DarkTitanAdvice';
 import EssenceOfInfusion from './Modules/Legendaries/EssenceOfInfusion';
 import Tearstone from './Modules/Legendaries/Tearstone';
 import T20 from './Modules/Legendaries/T20';
+import T19_2Set from './Modules/Legendaries/T19_2Set';
 import DarkmoonDeckPromises from './Modules/Legendaries/DarkmoonDeckPromises';
 
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
@@ -102,6 +103,7 @@ class CombatLogParser extends CoreCombatLogParser {
     essenceOfInfusion: EssenceOfInfusion,
     tearstone: Tearstone,
     t20: T20,
+    t19_2set: T19_2Set,
     // TODO:
     // Edraith
     // Aman'Thul's Wisdom

--- a/src/Parser/RestoDruid/Modules/Legendaries/T19_2Set.js
+++ b/src/Parser/RestoDruid/Modules/Legendaries/T19_2Set.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import Mastery from '../Features/Mastery';
+
+class T19_2Set extends Module {
+  static dependencies = {
+    mastery: Mastery,
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasBuff(SPELLS.RESTO_DRUID_T19_2SET_BONUS_BUFF.id);
+  }
+
+  item() {
+    const healing = this.mastery.getBuffBenefit(SPELLS.ASTRAL_HARMONY.id);
+
+    return {
+      id: `spell-${SPELLS.RESTO_DRUID_T19_2SET_BONUS_BUFF.id}`,
+      icon: <SpellIcon id={SPELLS.RESTO_DRUID_T19_2SET_BONUS_BUFF.id} />,
+      title: <SpellLink id={SPELLS.RESTO_DRUID_T19_2SET_BONUS_BUFF.id} />,
+      result: this.owner.formatItemHealingDone(healing),
+    };
+  }
+}
+
+export default T19_2Set;

--- a/src/common/SPELLS_DRUID.js
+++ b/src/common/SPELLS_DRUID.js
@@ -283,6 +283,12 @@ export default {
   },
 
   // Sets:
+  // Hidden buffs that indicate set is equipped:
+  RESTO_DRUID_T19_2SET_BONUS_BUFF: {
+    id: 211165,
+    name: 'T19 2 set bonus',
+    icon: 'talentspec_druid_restoration',
+  },
   RESTO_DRUID_T20_2SET_BONUS_BUFF: {
     id: 242238,
     name: 'T20 2 set bonus',
@@ -293,6 +299,7 @@ export default {
     name: 'T20 4 set bonus',
     icon: 'inv_misc_herb_talandrasrose',
   },
+  // Visible procs produced by set:
   ASTRAL_HARMONY: { // 2pc T19
     id: 232378,
     name: 'Astral Harmony',


### PR DESCRIPTION
Added an item display for Resto Druid's T19 2pc bonus. Added module is basically just the display, all the backend work was already doing in the Mastery module.