### PR TITLE
[Guardian] Clean up module dependencies

### DIFF
--- a/src/Parser/GuardianDruid/Modules/Features/CastEfficiency.js
+++ b/src/Parser/GuardianDruid/Modules/Features/CastEfficiency.js
@@ -35,10 +35,9 @@ class CastEfficiency extends CoreCastEfficiency {
         if (!hasMightBuff) {
           return 6;
         }
-        const abilityTracker = combatant.owner.modules.abilityTracker;
 
-        const mightBuff = abilityTracker.getAbility(SPELLS.INCARNATION_OF_URSOC.id).casts || 0;
         const fightDuration = combatant.owner.fightDuration/1000;
+        const mightBuff = Math.ceil(fightDuration / 180);
         const castsDuringMight = (mightBuff * 30) / (1.5 / (1+haste));
         const castsOutsideMight = (fightDuration - (mightBuff * 30)) / (6 / (1+haste));
         return fightDuration / (castsDuringMight + castsOutsideMight);

--- a/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
@@ -4,15 +4,18 @@ import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import GuardianOfElune from './GuardianOfElune';
 
 class FrenziedRegenGoEProcs extends Module {
   static dependencies = {
+    combatants: Combatants,
     guardianOfElune: GuardianOfElune,
   };
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.GUARDIAN_OF_ELUNE_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.GUARDIAN_OF_ELUNE_TALENT.id);
   }
 
   statistic() {
@@ -29,5 +32,5 @@ class FrenziedRegenGoEProcs extends Module {
   }
   statisticOrder = STATISTIC_ORDER.CORE(8);
 }
-  
+
 export default FrenziedRegenGoEProcs;

--- a/src/Parser/GuardianDruid/Modules/Features/GalacticGuardian.js
+++ b/src/Parser/GuardianDruid/Modules/Features/GalacticGuardian.js
@@ -5,11 +5,15 @@ import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
 import SPELLS from 'common/SPELLS';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 const GG_DURATION = 10000;
 const debug = false;
 
 class GalacticGuardian extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
 
   GGProcsTotal = 0;
   lastGGProcTime = 0;
@@ -18,7 +22,7 @@ class GalacticGuardian extends Module {
   nonGGMoonFire = 0;
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.GALACTIC_GUARDIAN_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.GALACTIC_GUARDIAN_TALENT.id);
   }
 
   on_byPlayer_applybuff(event) {
@@ -76,7 +80,7 @@ class GalacticGuardian extends Module {
 
   statistic() {
     const unusedGGProcs = 1 - (this.consumedGGProc / this.GGProcsTotal);
-    
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.GALACTIC_GUARDIAN.id} />}

--- a/src/Parser/GuardianDruid/Modules/Features/GuardianOfElune.js
+++ b/src/Parser/GuardianDruid/Modules/Features/GuardianOfElune.js
@@ -5,11 +5,16 @@ import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
 import SPELLS from 'common/SPELLS';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 const GoE_DURATION = 15000;
 const debug = false;
 
 class GuardianOfElune extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
   GoEProcsTotal = 0;
   lastGoEProcTime = 0;
   consumedGoEProc = 0;
@@ -20,7 +25,7 @@ class GuardianOfElune extends Module {
   GoEFRegen = 0;
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.GUARDIAN_OF_ELUNE_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.GUARDIAN_OF_ELUNE_TALENT.id);
   }
 
   on_byPlayer_applybuff(event) {
@@ -88,7 +93,7 @@ class GuardianOfElune extends Module {
 
   suggestions(when) {
     const unusedGoEProcs = 1 - (this.consumedGoEProc / this.GoEProcsTotal);
-    
+
     when(unusedGoEProcs).isGreaterThan(0.3)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>You wasted {formatPercentage(unusedGoEProcs)}% of your <SpellLink id={SPELLS.GUARDIAN_OF_ELUNE.id} /> procs. Try to use the procs as soon as you get them so they are not overwritten.</span>)
@@ -101,7 +106,7 @@ class GuardianOfElune extends Module {
 
   statistic() {
     const unusedGoEProcs = 1 - (this.consumedGoEProc / this.GoEProcsTotal);
-    
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.GUARDIAN_OF_ELUNE.id} />}

--- a/src/Parser/GuardianDruid/Modules/Features/IronFurGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/IronFurGoEProcs.js
@@ -4,15 +4,18 @@ import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import GuardianOfElune from './GuardianOfElune';
 
 class IronFurGoEProcs extends Module {
   static dependencies = {
+    combatants: Combatants,
     guardianOfElune: GuardianOfElune,
   };
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.GUARDIAN_OF_ELUNE_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.GUARDIAN_OF_ELUNE_TALENT.id);
   }
 
   statistic() {
@@ -29,5 +32,5 @@ class IronFurGoEProcs extends Module {
   }
   statisticOrder = STATISTIC_ORDER.CORE(9);
 }
-  
+
 export default IronFurGoEProcs;

--- a/src/Parser/GuardianDruid/Modules/Items/DualDetermination.js
+++ b/src/Parser/GuardianDruid/Modules/Items/DualDetermination.js
@@ -1,13 +1,18 @@
 import ITEMS from 'common/ITEMS';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 const debug = true;
 
 class DualDetermination extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
   SURVIVAL_INSTINCT_STACKS = 2
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasFinger(ITEMS.DUAL_DETERMINATION.id);
+    this.active = this.combatants.selected.hasFinger(ITEMS.DUAL_DETERMINATION.id);
     if(this.active) {
         debug && console.log('Has Dual Determination');
         this.SURVIVAL_INSTINCT_STACKS = 3;

--- a/src/Parser/GuardianDruid/Modules/Items/FuryOfNature.js
+++ b/src/Parser/GuardianDruid/Modules/Items/FuryOfNature.js
@@ -5,17 +5,24 @@ import SPELLS from 'common/SPELLS';
 import MAGIC_SCHOOLS from 'common/MAGIC_SCHOOLS';
 import { formatNumber } from 'common/format';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
 const FURY_OF_NATURE_DAMAGE_MODIFIER = 0.3;
 
 class FuryOfNature extends Module {
+  static dependencies = {
+    combatants: Combatants,
+    abilityTracker: AbilityTracker,
+  };
+
   damageDone = 0;
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasBack(ITEMS.FURY_OF_NATURE.id);
+    this.active = this.combatants.selected.hasBack(ITEMS.FURY_OF_NATURE.id);
   }
 
   on_byPlayer_damage(event) {
-    if (this.owner.selectedCombatant.hasBuff(SPELLS.BEAR_FORM.id) && (event.ability.type === MAGIC_SCHOOLS.ids.NATURE || event.ability.type === MAGIC_SCHOOLS.ids.ARCANE)) {
+    if (this.combatants.selected.hasBuff(SPELLS.BEAR_FORM.id) && (event.ability.type === MAGIC_SCHOOLS.ids.NATURE || event.ability.type === MAGIC_SCHOOLS.ids.ARCANE)) {
       // Isolate the damage contribution of the legendary
       this.damageDone += (event.amount + event.absorbed) * FURY_OF_NATURE_DAMAGE_MODIFIER / (1 + FURY_OF_NATURE_DAMAGE_MODIFIER);
     }
@@ -24,7 +31,7 @@ class FuryOfNature extends Module {
   item() {
     const fightLengthSec = this.owner.fightDuration / 1000;
     const dps = this.damageDone / fightLengthSec;
-    const hps = this.owner.modules.abilityTracker.getAbility(SPELLS.FURY_OF_NATURE_HEAL.id).healingEffective / fightLengthSec;
+    const hps = this.abilityTracker.getAbility(SPELLS.FURY_OF_NATURE_HEAL.id).healingEffective / fightLengthSec;
 
     return {
       item: ITEMS.FURY_OF_NATURE,

--- a/src/Parser/GuardianDruid/Modules/Items/LuffaWrappings.js
+++ b/src/Parser/GuardianDruid/Modules/Items/LuffaWrappings.js
@@ -5,14 +5,19 @@ import ITEMS from 'common/ITEMS';
 import { formatNumber } from 'common/format';
 
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 const LUFFA_DAMAGE_MODIFIER = 0.25;
 
 class LuffaWrappings extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
   damageDone = 0;
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasWrists(ITEMS.LUFFA_WRAPPINGS.id);
+    this.active = this.combatants.selected.hasWrists(ITEMS.LUFFA_WRAPPINGS.id);
   }
 
   on_byPlayer_damage(event) {

--- a/src/Parser/GuardianDruid/Modules/Items/Skysecs.js
+++ b/src/Parser/GuardianDruid/Modules/Items/Skysecs.js
@@ -4,6 +4,7 @@ import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import ItemLink from 'common/ItemLink';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 import { formatPercentage, formatNumber } from 'common/format';
 
@@ -20,6 +21,10 @@ const SKYSECS_HOLD_HP_PER_CAST = 0.12;
  * boots.
  */
 class SkysecsHold extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
   currentCycleFRTicksLeft = 0;
   currentCycleSHTicksLeft = 0;
   potentialHeal = 0;
@@ -30,7 +35,7 @@ class SkysecsHold extends Module {
   averagePlayerHPs = [];
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasFeet(ITEMS.SKYSECS_HOLD.id);
+    this.active = this.combatants.selected.hasFeet(ITEMS.SKYSECS_HOLD.id);
   }
 
   /**

--- a/src/Parser/GuardianDruid/Modules/Spells/FrenziedRegeneration.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/FrenziedRegeneration.js
@@ -5,6 +5,7 @@ import { formatPercentage } from 'common/format';
 import SpellLink from 'common/SpellLink';
 
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 const WILDFLESH_MODIFIER_PER_RANK = 0.05;
 const FR_WINDOW_MS = 5000;
@@ -14,6 +15,10 @@ const HEAL_THRESHOLD = 0.2;
 const HP_THRESHOLD = 0.7;
 
 class FrenziedRegeneration extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
   castData = [];
   damageEventsInWindow = [];
   _healModifier = 0.5;
@@ -40,7 +45,7 @@ class FrenziedRegeneration extends Module {
   }
 
   on_initialized() {
-    const player = this.owner.selectedCombatant;
+    const player = this.combatants.selected;
     const wildfleshRank = player.traitsBySpellId[SPELLS.WILDFLESH_TRAIT.id];
     const fleshknittingRank = player.traitsBySpellId[SPELLS.FLESHKNITTING_TRAIT.id];
     const versModifier = player.versatilityPercentage;
@@ -63,7 +68,7 @@ class FrenziedRegeneration extends Module {
       const damageTakenInWindow = this.damageEventsInWindow.reduce((total, event) => total + event.damage, 0);
 
       // TODO: is event ordering consistent here? (this cast event needs to happen before GoE removebuff)
-      const goeModifier = this.owner.selectedCombatant.hasBuff(SPELLS.GUARDIAN_OF_ELUNE.id) ? 1.2 : 1;
+      const goeModifier = this.combatants.selected.hasBuff(SPELLS.GUARDIAN_OF_ELUNE.id) ? 1.2 : 1;
 
       const healAmount = damageTakenInWindow * this.healModifier * goeModifier;
       const healAsPercentHP = healAmount / event.maxHitPoints;

--- a/src/Parser/GuardianDruid/Modules/Spells/IronFur.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/IronFur.js
@@ -4,11 +4,15 @@ import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 
 const debug = false;
 
 class IronFur extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
 
   lastIronfurBuffApplied = 0;
   physicalHitsWithIronFur = 0;
@@ -29,7 +33,7 @@ class IronFur extends Module {
       this.lastIronfurBuffApplied = 0;
     }
   }
-  
+
   on_toPlayer_damage(event) {
     // Physical
     if (event.ability.type === 1) {
@@ -56,7 +60,7 @@ class IronFur extends Module {
 
   suggestions(when) {
     const physicalDamageMitigatedPercent = this.physicalDamageWithIronFur/(this.physicalDamageWithIronFur+this.physicalDamageWithoutIronFur);
-    
+
     when(physicalDamageMitigatedPercent).isLessThan(0.90)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>You only had the <SpellLink id={SPELLS.IRONFUR.id} /> buff for {formatPercentage(actual)}% of physical damage taken. You should have the Ironfur buff up to mitigate as much physical damage as possible.</span>)
@@ -68,10 +72,10 @@ class IronFur extends Module {
   }
 
   statistic() {
-    const totalIronFurTime = this.owner.selectedCombatant.getBuffUptime(SPELLS.IRONFUR.id);
+    const totalIronFurTime = this.combatants.selected.getBuffUptime(SPELLS.IRONFUR.id);
     const physicalHitsMitigatedPercent = this.physicalHitsWithIronFur/(this.physicalHitsWithIronFur+this.physicalHitsWithoutIronFur);
     const physicalDamageMitigatedPercent = this.physicalDamageWithIronFur/(this.physicalDamageWithIronFur+this.physicalDamageWithoutIronFur);
-    
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.IRONFUR.id} />}
@@ -88,5 +92,5 @@ class IronFur extends Module {
   }
   statisticOrder = STATISTIC_ORDER.CORE(10);
 }
-  
+
 export default IronFur;

--- a/src/Parser/GuardianDruid/Modules/Spells/Moonfire.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/Moonfire.js
@@ -4,11 +4,16 @@ import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
+import Enemies from 'Parser/Core/Modules/Enemies';
 import SPELLS from 'common/SPELLS';
 
 class Moonfire extends Module {
+  static dependencies = {
+    enemies: Enemies,
+  };
+
   suggestions(when) {
-    const moonfireUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.owner.fightDuration;
+    const moonfireUptimePercentage = this.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.owner.fightDuration;
 
     when(moonfireUptimePercentage).isLessThan(0.95)
       .addSuggestion((suggest, actual, recommended) => {
@@ -21,8 +26,8 @@ class Moonfire extends Module {
   }
 
   statistic() {
-    const moonfireUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.owner.fightDuration;
-    
+    const moonfireUptimePercentage = this.enemies.getBuffUptime(SPELLS.MOONFIRE_BEAR.id) / this.owner.fightDuration;
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.MOONFIRE_BEAR.id} />}
@@ -33,5 +38,5 @@ class Moonfire extends Module {
   }
   statisticOrder = STATISTIC_ORDER.CORE(12);
 }
-  
+
 export default Moonfire;

--- a/src/Parser/GuardianDruid/Modules/Spells/Pulverize.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/Pulverize.js
@@ -4,17 +4,22 @@ import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 
 class Pulverize extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
   on_initialized() {
-    this.active = this.owner.selectedCombatant.hasTalent(SPELLS.PULVERIZE_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.PULVERIZE_TALENT.id);
   }
 
   suggestions(when) {
-    const pulverizeUptimePercentage = this.owner.selectedCombatant.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.owner.fightDuration;
-    
-    this.owner.selectedCombatant.hasTalent(SPELLS.PULVERIZE_TALENT.id) && 
+    const pulverizeUptimePercentage = this.combatants.selected.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.owner.fightDuration;
+
+    this.combatants.selected.hasTalent(SPELLS.PULVERIZE_TALENT.id) &&
     when(pulverizeUptimePercentage).isLessThan(0.9)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span> Your <SpellLink id={SPELLS.PULVERIZE_TALENT.id} /> uptime was {formatPercentage(pulverizeUptimePercentage)}%, unless there are extended periods of downtime it should be over should be near 100%. <br/>All targets deal less damage to you due to the <SpellLink id={SPELLS.PULVERIZE_BUFF.id} /> buff.</span>)
@@ -26,8 +31,8 @@ class Pulverize extends Module {
   }
 
   statistic() {
-    const pulverizeUptimePercentage = this.owner.selectedCombatant.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.owner.fightDuration;
-    
+    const pulverizeUptimePercentage = this.combatants.selected.getBuffUptime(SPELLS.PULVERIZE_BUFF.id) / this.owner.fightDuration;
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.PULVERIZE_TALENT.id} />}
@@ -38,5 +43,5 @@ class Pulverize extends Module {
   }
   statisticOrder = STATISTIC_ORDER.CORE(13);
 }
-  
+
 export default Pulverize;

--- a/src/Parser/GuardianDruid/Modules/Spells/Thrash.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/Thrash.js
@@ -4,13 +4,17 @@ import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Module from 'Parser/Core/Module';
+import Enemies from 'Parser/Core/Modules/Enemies';
 import SPELLS from 'common/SPELLS';
 
 class Thrash extends Module {
+  static dependencies = {
+    enemies: Enemies,
+  };
 
   suggestions(when) {
-    const thrashUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.owner.fightDuration;
-    
+    const thrashUptimePercentage = this.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.owner.fightDuration;
+
     when(thrashUptimePercentage).isLessThan(0.95)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span> Your <SpellLink id={SPELLS.THRASH_BEAR_DOT.id} /> uptime was {formatPercentage(thrashUptimePercentage)}%, unless you have extended periods of downtime it should be near 100%. <br/>Thrash applies a bleed which buffs the damage of <SpellLink id={SPELLS.MANGLE_BEAR.id} /> by 20%.  Thrash uptime is especially important if you are talented into <SpellLink id={SPELLS.REND_AND_TEAR_TALENT.id} />, since it buffs the rest of your damage and gives you extra damage reduction.</span>)
@@ -22,8 +26,8 @@ class Thrash extends Module {
   }
 
   statistic() {
-    const thrashUptimePercentage = this.owner.modules.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.owner.fightDuration;
-   
+    const thrashUptimePercentage = this.enemies.getBuffUptime(SPELLS.THRASH_BEAR_DOT.id) / this.owner.fightDuration;
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.THRASH_BEAR.id} />}
@@ -34,5 +38,5 @@ class Thrash extends Module {
   }
   statisticOrder = STATISTIC_ORDER.CORE(11);
 }
-  
+
 export default Thrash;

--- a/src/Parser/GuardianDruid/Modules/Talents/Earthwarden.js
+++ b/src/Parser/GuardianDruid/Modules/Talents/Earthwarden.js
@@ -3,12 +3,15 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
 import StatisticBox from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 
 import { formatNumber, formatPercentage } from 'common/format';
+import DamageTaken from '../Core/DamageTaken';
 
 const EARTHWARDEN_REDUCTION_MODIFIER = 0.3;
 
@@ -19,12 +22,18 @@ const ABILITIES_THAT_CONSUME_EW = [
 ];
 
 class Earthwarden extends Module {
+  static dependencies = {
+    combatants: Combatants,
+    abilityTracker: AbilityTracker,
+    damageTaken: DamageTaken,
+  };
+
   damageFromMelees = 0;
   swingsMitigated = 0;
   totalSwings = 0;
 
   on_initialized() {
-    this.active = this.owner.selectedCombatant.lv90Talent === SPELLS.EARTHWARDEN_TALENT.id;
+    this.active = this.combatants.selected.lv90Talent === SPELLS.EARTHWARDEN_TALENT.id;
   }
 
   on_toPlayer_damage(event) {
@@ -46,7 +55,7 @@ class Earthwarden extends Module {
   }
 
   get hps() {
-    const healingDone = this.owner.modules.abilityTracker.getAbility(SPELLS.EARTHWARDEN_BUFF.id).healingEffective;
+    const healingDone = this.abilityTracker.getAbility(SPELLS.EARTHWARDEN_BUFF.id).healingEffective;
     const fightLengthSec = this.owner.fightDuration / 1000;
     return healingDone / fightLengthSec;
   }
@@ -56,7 +65,7 @@ class Earthwarden extends Module {
   }
 
   get meleeDamageContribution() {
-    const totalDamageTaken = this.owner.modules.damageTaken.total.effective;
+    const totalDamageTaken = this.damageTaken.total.effective;
     return this.damageFromMelees / totalDamageTaken;
   }
 


### PR DESCRIPTION
Replaces most instances of `this.owner.modules` and `this.owner.selectedCombatant` in the guardian modules with the dependency injection pattern.  The remaining references are to `this.owner.fightDuration`, which does not currently have a better solution.

This PR also contains a change to the CastEfficiency of Thrash.  Previously, if Incarnation was talented, the maximum Thrash Casts were calculated based on the actual number of casts of Incarnation in the encounter.  Now, the maximum number of potential Incarnation casts is used to compute potential Thrash count, so poor Incarn cast efficiency will also lead to poor Thrash cast efficiency.  

This change should help better identify low Thrash counts, but was also necessary in order to remove the dependency on `owner.modules.abilityTracker` from within `CastEfficiency`.