### PR TITLE
Cinidaria the Symbiote

### DIFF
--- a/src/Main/DevelopmentTab.js
+++ b/src/Main/DevelopmentTab.js
@@ -207,20 +207,20 @@ ${properties.map(prop => `  ${prop},`).join('\n')}
                 <td>{formatThousands(cast.healingCriticalOverheal)}</td>
               </tr>
             )}
-            {cast.damangeHits && (
+            {cast.damageHits && (
               <tr>
                 <td>regular damage</td>
-                <td>{cast.damangeHits}</td>
-                <td>{formatThousands(cast.damangeEffective)}</td>
-                <td>{formatThousands(cast.damangeAbsorbed)}</td>
+                <td>{cast.damageHits}</td>
+                <td>{formatThousands(cast.damageEffective)}</td>
+                <td>{formatThousands(cast.damageAbsorbed)}</td>
               </tr>
             )}
-            {cast.damangeCriticalHits && (
+            {cast.damageCriticalHits && (
               <tr>
                 <td>critical damage</td>
-                <td>{cast.damangeCriticalHits}</td>
-                <td>{formatThousands(cast.damangeCriticalEffective)}</td>
-                <td>{formatThousands(cast.damangeCriticalAbsorbed)}</td>
+                <td>{cast.damageCriticalHits}</td>
+                <td>{formatThousands(cast.damageCriticalEffective)}</td>
+                <td>{formatThousands(cast.damageCriticalAbsorbed)}</td>
               </tr>
             )}
           </tbody>

--- a/src/Parser/Core/Modules/AbilityTracker.js
+++ b/src/Parser/Core/Modules/AbilityTracker.js
@@ -62,16 +62,16 @@ class DamageTracker extends HealingTracker {
     const spellId = event.ability.guid;
     const cast = this.getAbility(spellId, event.ability);
 
-    cast.damangeHits = (cast.damangeHits || 0) + 1;
+    cast.damageHits = (cast.damageHits || 0) + 1;
     // TODO: Use DamageValue class
-    cast.damangeEffective = (cast.damangeEffective || 0) + (event.amount || 0);
-    cast.damangeAbsorbed = (cast.damangeAbsorbed || 0) + (event.absorbed || 0); // Not sure
+    cast.damageEffective = (cast.damageEffective || 0) + (event.amount || 0);
+    cast.damageAbsorbed = (cast.damageAbsorbed || 0) + (event.absorbed || 0); // Not sure
 
     const isCrit = event.hitType === HIT_TYPES.CRIT;
     if (isCrit) {
-      cast.damangeCriticalHits = (cast.damangeCriticalHits || 0) + 1;
-      cast.damangeCriticalEffective = (cast.damangeCriticalEffective || 0) + (event.amount || 0);
-      cast.damangeCriticalAbsorbed = (cast.damangeCriticalAbsorbed || 0) + (event.absorbed || 0); // Not sure
+      cast.damageCriticalHits = (cast.damageCriticalHits || 0) + 1;
+      cast.damageCriticalEffective = (cast.damageCriticalEffective || 0) + (event.amount || 0);
+      cast.damageCriticalAbsorbed = (cast.damageCriticalAbsorbed || 0) + (event.absorbed || 0); // Not sure
     }
   }
 }

--- a/src/Parser/Core/Modules/Items/Cinidaria.js
+++ b/src/Parser/Core/Modules/Items/Cinidaria.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import { formatNumber } from 'common/format';
+
+import Combatants from 'Parser/Core/Modules/Combatants';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+
+import Module from 'Parser/Core/Module';
+
+class Cinidaria extends Module {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasWaist(ITEMS.CINIDARIA_THE_SYMBIOTE.id);
+  }
+
+  item() {
+    const fightLengthSec = this.owner.fightDuration / 1000;
+    const symbioteStrike = this.abilityTracker.getAbility(SPELLS.SYMBIOTE_STRIKE.id);
+    const dps = symbioteStrike.damageEffective / fightLengthSec;
+    const hps = symbioteStrike.healingEffective / fightLengthSec;
+
+    return {
+      item: ITEMS.CINIDARIA_THE_SYMBIOTE,
+      result: (
+        <span>
+          {formatNumber(dps)} DPS / {formatNumber(hps)} HPS
+        </span>
+      ),
+    };
+  }
+}
+
+export default Cinidaria;

--- a/src/Parser/ElementalShaman/CombatLogParser.js
+++ b/src/Parser/ElementalShaman/CombatLogParser.js
@@ -80,12 +80,12 @@ class CombatLogParser extends CoreCombatLogParser {
 
   generateResults() {
     const results = super.generateResults();
-    
+
     // const hasEchosElements = this.selectedCombatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id);
     // const hasAscendance = this.selectedCombatant.hasTalent(SPELLS.ASCENDANCE_ELEMENTAL_TALENT.id);
     // const hasLightningRod = this.selectedCombatant.hasTalent(SPELLS.LIGHTNING_ROD.id);
     const hasIcefury = this.selectedCombatant.hasTalent(SPELLS.ICEFURY_TALENT.id);
-    
+
     const abilityTracker = this.modules.abilityTracker;
     const getAbility = spellId => abilityTracker.getAbility(spellId);
 
@@ -150,7 +150,7 @@ class CombatLogParser extends CoreCombatLogParser {
                   marginTop: '-.1em',
                 }}
               />
-              {overloadLavaBurst.damangeHits}{' '}
+              {overloadLavaBurst.damageHits}{' '}
             </span>
             {' '}
             <span>
@@ -161,7 +161,7 @@ class CombatLogParser extends CoreCombatLogParser {
                   marginTop: '-.1em',
                 }}
               />
-              {overloadLightningBolt.damangeHits}{' '}
+              {overloadLightningBolt.damageHits}{' '}
             </span>
             {' '}
             <span>
@@ -172,7 +172,7 @@ class CombatLogParser extends CoreCombatLogParser {
                   marginTop: '-.1em',
                 }}
               />
-              {overloadElementalBlast.damangeHits}{' '}
+              {overloadElementalBlast.damageHits}{' '}
             </span>
             {' '}
             <span className="hideWider1200">
@@ -183,7 +183,7 @@ class CombatLogParser extends CoreCombatLogParser {
                   marginTop: '-.1em',
                 }}
               />
-              {overloadChainLightning.damangeHits}{' '}
+              {overloadChainLightning.damageHits}{' '}
             </span>
             { hasIcefury &&
               <span className="hideWider1200">
@@ -194,7 +194,7 @@ class CombatLogParser extends CoreCombatLogParser {
                     marginTop: '-.1em',
                   }}
                 />
-                {overloadIcefury ? overloadIcefury.damangeHits : '-' }{' '}
+                {overloadIcefury ? overloadIcefury.damageHits : '-' }{' '}
               </span>
             }
           </span>

--- a/src/Parser/GuardianDruid/CombatLogParser.js
+++ b/src/Parser/GuardianDruid/CombatLogParser.js
@@ -6,6 +6,8 @@ import Talents from 'Main/Talents';
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
+import Cinidaria from 'Parser/Core/Modules/Items/Cinidaria';
+
 import CastEfficiency from './Modules/Features/CastEfficiency';
 import DamageTaken from './Modules/Core/DamageTaken';
 import HealingDone from './Modules/Core/HealingDone';
@@ -60,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     skysecs: SkysecsHold,
     luffaWrappings: LuffaWrappings,
     furyOfNature: FuryOfNature,
+    cinidaria: Cinidaria,
   };
 
   generateResults() {

--- a/src/Parser/VengeanceDemonHunter/Modules/Statistics/Spells/ImmolationAura.js
+++ b/src/Parser/VengeanceDemonHunter/Modules/Statistics/Spells/ImmolationAura.js
@@ -19,7 +19,7 @@ class ImmolationAura extends Module {
 
     if(this.owner.modules.abilityTracker.abilities[SPELLS.IMMOLATION_AURA.id]) {
 
-      this.immolationAuraDamage = this.owner.modules.abilityTracker.abilities[SPELLS.IMMOLATION_AURA_FIRST_STRIKE.id].damangeEffective + this.owner.modules.abilityTracker.abilities[SPELLS.IMMOLATION_AURA_BUFF.id].damangeEffective;
+      this.immolationAuraDamage = this.owner.modules.abilityTracker.abilities[SPELLS.IMMOLATION_AURA_FIRST_STRIKE.id].damageEffective + this.owner.modules.abilityTracker.abilities[SPELLS.IMMOLATION_AURA_BUFF.id].damageEffective;
     }
 
     return (

--- a/src/Parser/VengeanceDemonHunter/Modules/Statistics/Spells/SigilOfFlame.js
+++ b/src/Parser/VengeanceDemonHunter/Modules/Statistics/Spells/SigilOfFlame.js
@@ -18,7 +18,7 @@ class SigilOfFlame extends Module {
     const sigilOfFlameUptimePercentage = sigilOfFlameUptime / this.owner.fightDuration;
 
     if(this.owner.modules.abilityTracker.abilities[SPELLS.SIGIL_OF_FLAME_DEBUFF.id]) {
-      this.sigilOfFlameDamage = this.owner.modules.abilityTracker.abilities[SPELLS.SIGIL_OF_FLAME_DEBUFF.id].damangeEffective;
+      this.sigilOfFlameDamage = this.owner.modules.abilityTracker.abilities[SPELLS.SIGIL_OF_FLAME_DEBUFF.id].damageEffective;
     }
 
 

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -247,6 +247,12 @@ export default {
     name: 'Drums of the Mountain',
     icon: 'inv_archaeology_70_tauren_drum',
   },
+  // Cinidaria
+  SYMBIOTE_STRIKE: {
+    id: 207694,
+    name: 'Symbiote Strike',
+    icon: 'inv_leather_raiddruid_m_01belt',
+  },
 
   // Encounter mechanics
   RECURSIVE_STRIKES_ENEMY: {


### PR DESCRIPTION
Adds a common module for tracking Cinidaria dps and hps.

Also fixes a typo in AbilityTracker (`damange` -> `damage`), and all occurrences of the typo in other modules.