### PR TITLE
[Core] + [Balance Druid] Added functionality to CoreABC to support stackable haste buffs

### DIFF
--- a/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
@@ -36,12 +36,12 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     static STACKABLE_HASTE_BUFFS = {
       ...CoreAlwaysBeCasting.STACKABLE_HASTE_BUFFS,
       //Moonkin specific
-      [242232] : { //Astral Acceleration - From T20 4p
+      242232 : { //Astral Acceleration - From T20 4p
         Haste: () => 0.03,
         CurrentStacks: 0, 
         MaxStacks: 5,
       }, 
-      [202942] : { //StarPower - From casts in Incarnation / CA
+      202942 : { //StarPower - From casts in Incarnation / CA
         Haste: (combatant) => (
           combatant.hasTalent(SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id) ? 0.01 : 0.03
         ), 

--- a/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
@@ -1,5 +1,5 @@
-import SPELLS from 'common/SPELLS';
 import React from 'react';
+import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Icon from 'common/Icon';

--- a/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
@@ -1,19 +1,12 @@
-import Module from 'Parser/Core/Module';
 import SPELLS from 'common/SPELLS';
 import React from 'react';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Icon from 'common/Icon';
+
+import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
   
-import Combatants from 'Parser/Core/Modules/Combatants';
-  
-const debug = false;
-  
-class AlwaysBeCasting extends Module {
-    static dependencies = {
-      combatants: Combatants,
-    };
-  
+class AlwaysBeCasting extends CoreAlwaysBeCasting {
     static ABILITIES_ON_GCD = [
       // Moonkin:
       SPELLS.MOONFIRE.id,
@@ -33,216 +26,28 @@ class AlwaysBeCasting extends Module {
       SPELLS.WILD_CHARGE_TALENT.id,
     ];
 
-    static SHAPESHIFTING_ABILITIES = [
-      ///TODO Add shapeshifting
+    static FULLGCD_ABILITIES = [
+      ///Shapeshifts
       SPELLS.MOONKIN_FORM.id,
       SPELLS.DISPLACER_BEAST_TALENT.id,
+      SPELLS.BEAR_FORM.id,
     ];
-      
-    /* eslint-disable no-useless-computed-key */
-    static HASTE_BUFFS = { // This includes debuffs
-      [SPELLS.BLOODLUST.id]: 0.3,
-      [SPELLS.HEROISM.id]: 0.3,
-      [SPELLS.TIME_WARP.id]: 0.3,
-      [SPELLS.ANCIENT_HYSTERIA.id]: 0.3, // Hunter pet BL
-      [SPELLS.NETHERWINDS.id]: 0.3, // Hunter pet BL
-      [SPELLS.DRUMS_OF_FURY.id]: 0.25,
-      [SPELLS.DRUMS_OF_THE_MOUNTAIN.id]: 0.25,
-      [SPELLS.DRUMS_OF_RAGE.id]: 0.25,
-      [SPELLS.BERSERKING.id]: 0.15,
-      [240673]: 800 / 37500, // Shadow Priest artifact trait that shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
-      [242543]: 3619 / 37500, // Chalice of Moonlight Haste buff (900 item level since we can't scale with item level yet)
-      // Boss abilities:
-      [209166]: 0.3, // DEBUFF - Fast Time from Elisande
-      [209165]: -0.3, // DEBUFF - Slow Time from Elisande
-    };
 
-    //Stackable haste buffs - Set Haste per stack and MaxStacks (0 for no max)
     static STACKABLE_HASTE_BUFFS = {
+      ...CoreAlwaysBeCasting.STACKABLE_HASTE_BUFFS,
       //Moonkin specific
-      [242232] : { Haste: 0.03, CurrentStacks: 0, MaxStacks: 5}, //Astral Acceleration - From T20 4p
-      [202942] : { Haste: 0.03, CurrentStacks: 0, MaxStacks: 0}, //StarPower - From casts in Incarnation / CA
-    }
-  
-    totalTimeWasted = 0;
-    totalHealingTimeWasted = 0;
-  
-    lastCastFinishedTimestamp = null;
-    lastHealingCastFinishedTimestamp = null;
-  
-    _currentlyCasting = null;
-    on_byPlayer_begincast(event) {
-      const cast = {
-        begincast: event,
-        cast: null,
-      };
-  
-      this._currentlyCasting = cast;
-    }
-    on_byPlayer_cast(event) {
-      const spellId = event.ability.guid;
-      const isOnGcd = this.constructor.ABILITIES_ON_GCD.indexOf(spellId) !== -1;
-      // This fixes a crash when boss abilities are registered as casts which could even happen while channeling. For example on Trilliax: http://i.imgur.com/7QAFy1q.png
-      if (!isOnGcd) {
-        return;
-      }
-  
-      if (this._currentlyCasting && this._currentlyCasting.begincast.ability.guid !== event.ability.guid) {
-        // This is a different spell then registered in `begincast`, previous cast was interrupted
-        this._currentlyCasting = null;
-      }
-  
-      const logEntry = this._currentlyCasting || {
-        begincast: null,
-      };
-      logEntry.cast = event;
-  
-      this.processCast(logEntry);
-      this._currentlyCasting = null;
-    }
-  
-    processCast({ begincast, cast }) {
-      if (!cast) {
-        return;
-      }
-      const spellId = cast.ability.guid;
-      const isOnGcd = this.constructor.ABILITIES_ON_GCD.indexOf(spellId) !== -1;
-      const isShapeshift = this.constructor.SHAPESHIFTING_ABILITIES.indexOf(spellId) !== -1;
-  
-      if (!isOnGcd) {
-        debug && console.log(`%cABC: ${cast.ability.name} (${spellId}) ignored`, 'color: gray');
-        return;
-      }
-  
-      const globalCooldown = isShapeshift ? 1.5 : this.constructor.calculateGlobalCooldown(this.currentHaste) * 1000;
-  
-      const castStartTimestamp = (begincast ? begincast : cast).timestamp;
-  
-      this.recordCastTime(
-        castStartTimestamp,
-        globalCooldown,
-        begincast,
-        cast,
-        spellId
-      );
-    }
-    recordCastTime(
-      castStartTimestamp,
-      globalCooldown,
-      begincast,
-      cast,
-      spellId
-    ) {
-      const timeWasted = castStartTimestamp - (this.lastCastFinishedTimestamp || this.owner.fight.start_time);
-      this.totalTimeWasted += timeWasted;
-  
-      debug && console.log(`ABC: tot.:${Math.floor(this.totalTimeWasted)}\tthis:${Math.floor(timeWasted)}\t%c${cast.ability.name} (${spellId}): ${begincast ? 'channeled' : 'instant'}\t%cgcd:${Math.floor(globalCooldown)}\t%ccasttime:${cast.timestamp - castStartTimestamp}\tfighttime:${castStartTimestamp - this.owner.fight.start_time}`, 'color:red', 'color:green', 'color:black');
-  
-      this.lastCastFinishedTimestamp = Math.max(castStartTimestamp + globalCooldown, cast.timestamp);
-    }
-    baseHaste = null;
-    currentHaste = null;
-    on_initialized() {
-      const combatant = this.combatants.selected;
-      this.baseHaste = combatant.hastePercentage;
-      this.currentHaste = this.baseHaste;
-  
-      debug && console.log(`ABC: Current haste: ${this.currentHaste}`);
-    }
-
-    on_toPlayer_applybuff(event) {
-      this.applyActiveBuff(event);
-    }    
-    on_toPlayer_applybuffstack(event){
-      this.applyBuffStack(event);
-    }
-    on_toPlayer_removebuff(event) {
-      this.removeActiveBuff(event);
-    }
-    on_toPlayer_applydebuff(event) {
-      this.applyActiveBuff(event);
-    }
-    on_toPlayer_removedebuff(event) {
-      this.removeActiveBuff(event);
-    }
-
-    applyActiveBuff(event) {
-      const spellId = event.ability.guid;
-      let hasteGain = undefined;
-      
-      //Added check so it gets the correct one, and adds stacks if necessary
-      if (this.constructor.HASTE_BUFFS[spellId]){
-        hasteGain = this.constructor.HASTE_BUFFS[spellId];
-      }
-      else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
-        hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste;
-        this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks ++;
-      }
-
-      if (hasteGain) {
-        this.applyHasteGain(hasteGain);
-        
-        debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
-      }
-    }
-
-    //Added apply buff stack event for stackable haste buffs
-    applyBuffStack(event) {
-      const spellId = event.ability.guid;
-      const stackInfo = this.constructor.STACKABLE_HASTE_BUFFS[spellId];
-      let hasteGain = undefined;
-
-      if (stackInfo){
-        hasteGain = stackInfo.Haste;
-      }
-
-      if (hasteGain) {
-        this.applyHasteGain(hasteGain);
-
-        if (stackInfo.MaxStacks === 0 || stackInfo.CurrentStacks < stackInfo.MaxStacks)
-          stackInfo.CurrentStacks ++;
-  
-        debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
-      }
-    }
-
-    removeActiveBuff(event) {
-      const spellId = event.ability.guid;
-      let hasteGain = undefined;
-
-      //Added check so it gets the correct one
-      if (this.constructor.HASTE_BUFFS[spellId]){
-        hasteGain = this.constructor.HASTE_BUFFS[spellId];
-      }
-      else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
-        //When buff loss, it should loose haste equal to base buff haste * number of stacks
-        hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste * this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks;
-        this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks = 0;
-      }
-
-      if (hasteGain) {
-        this.applyHasteLoss(hasteGain);
-        
-        debug && console.log(`ABC: Current haste: ${this.currentHaste} (lost ${hasteGain} from ${spellId})`);
-      }
-    }
-  
-    static calculateGlobalCooldown(haste) {
-      const gcd = 1.5 / (1 + haste);
-      //Check the gcd doesnt go under the limit
-      return gcd > 0.75 ? gcd : 0.75;
-    }
-    static applyHasteGain(baseHaste, hasteGain) {
-      return baseHaste * (1 + hasteGain) + hasteGain;
-    }
-    applyHasteGain(hasteGain) {
-      this.currentHaste = this.constructor.applyHasteGain(this.currentHaste, hasteGain);
-    }
-    static applyHasteLoss(baseHaste, hasteLoss) {
-      return (baseHaste - hasteLoss) / (1 + hasteLoss);
-    }
-    applyHasteLoss(hasteGain) {
-      this.currentHaste = this.constructor.applyHasteLoss(this.currentHaste, hasteGain);
+      [242232] : { //Astral Acceleration - From T20 4p
+        Haste: () => 0.03,
+        CurrentStacks: 0, 
+        MaxStacks: 5,
+      }, 
+      [202942] : { //StarPower - From casts in Incarnation / CA
+        Haste: (combatant) => (
+          combatant.hasTalent(SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id) ? 0.01 : 0.03
+        ), 
+        CurrentStacks: 0, 
+        MaxStacks: 0,
+      }, 
     }
 
   suggestions(when) {

--- a/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
@@ -1,33 +1,250 @@
+import Module from 'Parser/Core/Module';
+import SPELLS from 'common/SPELLS';
 import React from 'react';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
-import SPELLS from 'common/SPELLS';
 import Icon from 'common/Icon';
-
-class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  static ABILITIES_ON_GCD = [
-    // Moonkin:
-    SPELLS.MOONFIRE.id,
-    SPELLS.SUNFIRE_CAST.id,
-    SPELLS.STARSURGE_MOONKIN.id,
-    SPELLS.STARFALL_CAST.id,
-    SPELLS.LUNAR_STRIKE.id,
-    SPELLS.SOLAR_WRATH_MOONKIN.id,
-    SPELLS.NEW_MOON.id,
-    SPELLS.HALF_MOON.id,
-    SPELLS.FULL_MOON.id,
-    SPELLS.MOONKIN_FORM,
-
-    // Talents
-    SPELLS.DISPLACER_BEAST_TALENT.id,
-    SPELLS.TYPHOON.id,
-    SPELLS.MASS_ENTANGLEMENT_TALENT.id,
-    SPELLS.FORCE_OF_NATURE_TALENT.id,
-    SPELLS.WILD_CHARGE_TALENT.id,
-  ];
-  ///TODO Add Moonkin haste buffs
   
+import Combatants from 'Parser/Core/Modules/Combatants';
+  
+const debug = false;
+  
+class AlwaysBeCasting extends Module {
+    static dependencies = {
+      combatants: Combatants,
+    };
+  
+    static ABILITIES_ON_GCD = [
+      // Moonkin:
+      SPELLS.MOONFIRE.id,
+      SPELLS.SUNFIRE_CAST.id,
+      SPELLS.STARSURGE_MOONKIN.id,
+      SPELLS.STARFALL_CAST.id,
+      SPELLS.LUNAR_STRIKE.id,
+      SPELLS.SOLAR_WRATH_MOONKIN.id,
+      SPELLS.NEW_MOON.id,
+      SPELLS.HALF_MOON.id,
+      SPELLS.FULL_MOON.id,
+  
+      // Talents
+      SPELLS.TYPHOON.id,
+      SPELLS.MASS_ENTANGLEMENT_TALENT.id,
+      SPELLS.FORCE_OF_NATURE_TALENT.id,
+      SPELLS.WILD_CHARGE_TALENT.id,
+    ];
+
+    static SHAPESHIFTING_ABILITIES = [
+      ///TODO Add shapeshifting
+      SPELLS.MOONKIN_FORM.id,
+      SPELLS.DISPLACER_BEAST_TALENT.id,
+    ];
+      
+    /* eslint-disable no-useless-computed-key */
+    static HASTE_BUFFS = { // This includes debuffs
+      [SPELLS.BLOODLUST.id]: 0.3,
+      [SPELLS.HEROISM.id]: 0.3,
+      [SPELLS.TIME_WARP.id]: 0.3,
+      [SPELLS.ANCIENT_HYSTERIA.id]: 0.3, // Hunter pet BL
+      [SPELLS.NETHERWINDS.id]: 0.3, // Hunter pet BL
+      [SPELLS.DRUMS_OF_FURY.id]: 0.25,
+      [SPELLS.DRUMS_OF_THE_MOUNTAIN.id]: 0.25,
+      [SPELLS.DRUMS_OF_RAGE.id]: 0.25,
+      [SPELLS.BERSERKING.id]: 0.15,
+      [240673]: 800 / 37500, // Shadow Priest artifact trait that shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
+      [242543]: 3619 / 37500, // Chalice of Moonlight Haste buff (900 item level since we can't scale with item level yet)
+      // Boss abilities:
+      [209166]: 0.3, // DEBUFF - Fast Time from Elisande
+      [209165]: -0.3, // DEBUFF - Slow Time from Elisande
+    };
+
+    //Stackable haste buffs - Set Haste per stack and MaxStacks (0 for no max)
+    static STACKABLE_HASTE_BUFFS = {
+      //Moonkin specific
+      [242232] : { Haste: 0.03, CurrentStacks: 0, MaxStacks: 5}, //Astral Acceleration - From T20 4p
+      [202942] : { Haste: 0.03, CurrentStacks: 0, MaxStacks: 0}, //StarPower - From casts in Incarnation / CA
+    }
+  
+    totalTimeWasted = 0;
+    totalHealingTimeWasted = 0;
+  
+    lastCastFinishedTimestamp = null;
+    lastHealingCastFinishedTimestamp = null;
+  
+    _currentlyCasting = null;
+    on_byPlayer_begincast(event) {
+      const cast = {
+        begincast: event,
+        cast: null,
+      };
+  
+      this._currentlyCasting = cast;
+    }
+    on_byPlayer_cast(event) {
+      const spellId = event.ability.guid;
+      const isOnGcd = this.constructor.ABILITIES_ON_GCD.indexOf(spellId) !== -1;
+      // This fixes a crash when boss abilities are registered as casts which could even happen while channeling. For example on Trilliax: http://i.imgur.com/7QAFy1q.png
+      if (!isOnGcd) {
+        return;
+      }
+  
+      if (this._currentlyCasting && this._currentlyCasting.begincast.ability.guid !== event.ability.guid) {
+        // This is a different spell then registered in `begincast`, previous cast was interrupted
+        this._currentlyCasting = null;
+      }
+  
+      const logEntry = this._currentlyCasting || {
+        begincast: null,
+      };
+      logEntry.cast = event;
+  
+      this.processCast(logEntry);
+      this._currentlyCasting = null;
+    }
+  
+    processCast({ begincast, cast }) {
+      if (!cast) {
+        return;
+      }
+      const spellId = cast.ability.guid;
+      const isOnGcd = this.constructor.ABILITIES_ON_GCD.indexOf(spellId) !== -1;
+      const isShapeshift = this.constructor.SHAPESHIFTING_ABILITIES.indexOf(spellId) !== -1;
+  
+      if (!isOnGcd) {
+        debug && console.log(`%cABC: ${cast.ability.name} (${spellId}) ignored`, 'color: gray');
+        return;
+      }
+  
+      const globalCooldown = isShapeshift ? 1.5 : this.constructor.calculateGlobalCooldown(this.currentHaste) * 1000;
+  
+      const castStartTimestamp = (begincast ? begincast : cast).timestamp;
+  
+      this.recordCastTime(
+        castStartTimestamp,
+        globalCooldown,
+        begincast,
+        cast,
+        spellId
+      );
+    }
+    recordCastTime(
+      castStartTimestamp,
+      globalCooldown,
+      begincast,
+      cast,
+      spellId
+    ) {
+      const timeWasted = castStartTimestamp - (this.lastCastFinishedTimestamp || this.owner.fight.start_time);
+      this.totalTimeWasted += timeWasted;
+  
+      debug && console.log(`ABC: tot.:${Math.floor(this.totalTimeWasted)}\tthis:${Math.floor(timeWasted)}\t%c${cast.ability.name} (${spellId}): ${begincast ? 'channeled' : 'instant'}\t%cgcd:${Math.floor(globalCooldown)}\t%ccasttime:${cast.timestamp - castStartTimestamp}\tfighttime:${castStartTimestamp - this.owner.fight.start_time}`, 'color:red', 'color:green', 'color:black');
+  
+      this.lastCastFinishedTimestamp = Math.max(castStartTimestamp + globalCooldown, cast.timestamp);
+    }
+    baseHaste = null;
+    currentHaste = null;
+    on_initialized() {
+      const combatant = this.combatants.selected;
+      this.baseHaste = combatant.hastePercentage;
+      this.currentHaste = this.baseHaste;
+  
+      debug && console.log(`ABC: Current haste: ${this.currentHaste}`);
+    }
+
+    on_toPlayer_applybuff(event) {
+      this.applyActiveBuff(event);
+    }    
+    on_toPlayer_applybuffstack(event){
+      this.applyBuffStack(event);
+    }
+    on_toPlayer_removebuff(event) {
+      this.removeActiveBuff(event);
+    }
+    on_toPlayer_applydebuff(event) {
+      this.applyActiveBuff(event);
+    }
+    on_toPlayer_removedebuff(event) {
+      this.removeActiveBuff(event);
+    }
+
+    applyActiveBuff(event) {
+      const spellId = event.ability.guid;
+      let hasteGain = undefined;
+      
+      //Added check so it gets the correct one, and adds stacks if necessary
+      if (this.constructor.HASTE_BUFFS[spellId]){
+        hasteGain = this.constructor.HASTE_BUFFS[spellId];
+      }
+      else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
+        hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste;
+        this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks ++;
+      }
+
+      if (hasteGain) {
+        this.applyHasteGain(hasteGain);
+        
+        debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
+      }
+    }
+
+    //Added apply buff stack event for stackable haste buffs
+    applyBuffStack(event) {
+      const spellId = event.ability.guid;
+      const stackInfo = this.constructor.STACKABLE_HASTE_BUFFS[spellId];
+      let hasteGain = undefined;
+
+      if (stackInfo){
+        hasteGain = stackInfo.Haste;
+      }
+
+      if (hasteGain) {
+        this.applyHasteGain(hasteGain);
+
+        if (stackInfo.MaxStacks === 0 || stackInfo.CurrentStacks < stackInfo.MaxStacks)
+          stackInfo.CurrentStacks ++;
+  
+        debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
+      }
+    }
+
+    removeActiveBuff(event) {
+      const spellId = event.ability.guid;
+      let hasteGain = undefined;
+
+      //Added check so it gets the correct one
+      if (this.constructor.HASTE_BUFFS[spellId]){
+        hasteGain = this.constructor.HASTE_BUFFS[spellId];
+      }
+      else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
+        //When buff loss, it should loose haste equal to base buff haste * number of stacks
+        hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste * this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks;
+        this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks = 0;
+      }
+
+      if (hasteGain) {
+        this.applyHasteLoss(hasteGain);
+        
+        debug && console.log(`ABC: Current haste: ${this.currentHaste} (lost ${hasteGain} from ${spellId})`);
+      }
+    }
+  
+    static calculateGlobalCooldown(haste) {
+      const gcd = 1.5 / (1 + haste);
+      //Check the gcd doesnt go under the limit
+      return gcd > 0.75 ? gcd : 0.75;
+    }
+    static applyHasteGain(baseHaste, hasteGain) {
+      return baseHaste * (1 + hasteGain) + hasteGain;
+    }
+    applyHasteGain(hasteGain) {
+      this.currentHaste = this.constructor.applyHasteGain(this.currentHaste, hasteGain);
+    }
+    static applyHasteLoss(baseHaste, hasteLoss) {
+      return (baseHaste - hasteLoss) / (1 + hasteLoss);
+    }
+    applyHasteLoss(hasteGain) {
+      this.currentHaste = this.constructor.applyHasteLoss(this.currentHaste, hasteGain);
+    }
+
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
     
@@ -55,5 +272,6 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
   }
   statisticOrder = STATISTIC_ORDER.CORE(0);
 }
+
 
 export default AlwaysBeCasting;

--- a/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
@@ -26,12 +26,13 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
       SPELLS.WILD_CHARGE_TALENT.id,
     ];
 
-    static FULLGCD_ABILITIES = [
+    static STATIC_GCD_ABILITIES = {
+      ...CoreAlwaysBeCasting.STATIC_GCD_ABILITIES,
       ///Shapeshifts
-      SPELLS.MOONKIN_FORM.id,
-      SPELLS.DISPLACER_BEAST_TALENT.id,
-      SPELLS.BEAR_FORM.id,
-    ];
+      [SPELLS.MOONKIN_FORM.id] : 1.5,
+      [SPELLS.DISPLACER_BEAST_TALENT.id] : 1.5,
+      [SPELLS.BEAR_FORM.id] : 1.5,
+    };
 
     static STACKABLE_HASTE_BUFFS = {
       ...CoreAlwaysBeCasting.STACKABLE_HASTE_BUFFS,

--- a/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/BalanceDruid/Modules/Features/AlwaysBeCasting.js
@@ -36,12 +36,12 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     static STACKABLE_HASTE_BUFFS = {
       ...CoreAlwaysBeCasting.STACKABLE_HASTE_BUFFS,
       //Moonkin specific
-      242232 : { //Astral Acceleration - From T20 4p
+      [SPELLS.ASTRAL_ACCELERATION.id] : { //Astral Acceleration - From T20 4p
         Haste: () => 0.03,
         CurrentStacks: 0, 
         MaxStacks: 5,
       }, 
-      202942 : { //StarPower - From casts in Incarnation / CA
+      [SPELLS.STAR_POWER.id] : { //StarPower - From casts in Incarnation / CA
         Haste: (combatant) => (
           combatant.hasTalent(SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id) ? 0.01 : 0.03
         ), 

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -153,7 +153,7 @@ class AlwaysBeCasting extends Module {
   }
   applyActiveBuff(event) {
     const spellId = event.ability.guid;
-    let hasteGain = undefined;
+    let hasteGain;
     
     //Added check so it gets the correct one, and adds stacks if necessary
     if (this.constructor.HASTE_BUFFS[spellId]){
@@ -174,7 +174,7 @@ class AlwaysBeCasting extends Module {
   applyBuffStack(event) {
     const spellId = event.ability.guid;
     const stackInfo = this.constructor.STACKABLE_HASTE_BUFFS[spellId];
-    let hasteGain = undefined;
+    let hasteGain;
 
     if (stackInfo){
       hasteGain = stackInfo.Haste(this.combatants.selected);
@@ -192,22 +192,22 @@ class AlwaysBeCasting extends Module {
   }
   removeActiveBuff(event) {
     const spellId = event.ability.guid;
-    let hasteGain = undefined;
+    let hasteLoss;
     
     //Added check so it gets the correct one
     if (this.constructor.HASTE_BUFFS[spellId]){
-      hasteGain = this.constructor.HASTE_BUFFS[spellId];
+      hasteLoss = this.constructor.HASTE_BUFFS[spellId];
     }
     else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
       //When buff loss, it should lose haste equal to base buff haste * number of stacks
-      hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste(this.combatants.selected) * this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks;
+      hasteLoss = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste(this.combatants.selected) * this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks;
       this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks = 0;
     }
 
-    if (hasteGain) {
-      this.applyHasteLoss(hasteGain);
+    if (hasteLoss) {
+      this.applyHasteLoss(hasteLoss);
 
-      debug && console.log(`ABC: Current haste: ${this.currentHaste} (lost ${hasteGain} from ${spellId})`);
+      debug && console.log(`ABC: Current haste: ${this.currentHaste} (lost ${hasteLoss} from ${spellId})`);
     }
   }
 

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -13,6 +13,10 @@ class AlwaysBeCasting extends Module {
   static ABILITIES_ON_GCD = [
     // Extend this class and override this property in your spec class to implement this module.
   ];
+  static FULLGCD_ABILITIES = [
+    //Override this property in your spec class
+  ];
+
   /* eslint-disable no-useless-computed-key */
   static HASTE_BUFFS = { // This includes debuffs
     [SPELLS.BLOODLUST.id]: 0.3,
@@ -36,6 +40,10 @@ class AlwaysBeCasting extends Module {
     [209165]: -0.3, // DEBUFF - Slow Time from Elisande
     // [208944]: -Infinity, // DEBUFF - Time Stop from Elisande
   };
+
+  //Stackable haste buffs - Set Haste per stack and MaxStacks (0 for no max)
+  static STACKABLE_HASTE_BUFFS = {    
+  }
 
   totalTimeWasted = 0;
   totalHealingTimeWasted = 0;
@@ -80,13 +88,14 @@ class AlwaysBeCasting extends Module {
     }
     const spellId = cast.ability.guid;
     const isOnGcd = this.constructor.ABILITIES_ON_GCD.indexOf(spellId) !== -1;
+    const isFullGcd = this.constructor.FULLGCD_ABILITIES.indexOf(spellId) !== -1;
 
     if (!isOnGcd) {
       debug && console.log(`%cABC: ${cast.ability.name} (${spellId}) ignored`, 'color: gray');
       return;
     }
 
-    const globalCooldown = this.constructor.calculateGlobalCooldown(this.currentHaste) * 1000;
+    const globalCooldown = isFullGcd ? 1500 : this.constructor.calculateGlobalCooldown(this.currentHaste) * 1000;
 
     const castStartTimestamp = (begincast ? begincast : cast).timestamp;
 
@@ -124,6 +133,10 @@ class AlwaysBeCasting extends Module {
   on_toPlayer_applybuff(event) {
     this.applyActiveBuff(event);
   }
+  //Added event listener for buff stacks applied
+  on_toPlayer_applybuffstack(event){
+    this.applyBuffStack(event);
+  }
   on_toPlayer_removebuff(event) {
     this.removeActiveBuff(event);
   }
@@ -135,16 +148,57 @@ class AlwaysBeCasting extends Module {
   }
   applyActiveBuff(event) {
     const spellId = event.ability.guid;
-    const hasteGain = this.constructor.HASTE_BUFFS[spellId];
+    let hasteGain = undefined;
+    
+    //Added check so it gets the correct one, and adds stacks if necessary
+    if (this.constructor.HASTE_BUFFS[spellId]){
+      hasteGain = this.constructor.HASTE_BUFFS[spellId];
+    }
+    else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
+      hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste(this.combatants.selected);
+      this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks ++;
+    }
+
     if (hasteGain) {
       this.applyHasteGain(hasteGain);
 
       debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
     }
   }
+  //Added apply buff stack event for stackable haste buffs
+  applyBuffStack(event) {
+    const spellId = event.ability.guid;
+    const stackInfo = this.constructor.STACKABLE_HASTE_BUFFS[spellId];
+    let hasteGain = undefined;
+
+    if (stackInfo){
+      hasteGain = stackInfo.Haste(this.combatants.selected);
+    }
+
+    if (hasteGain) {
+      //Only add haste stack if max stacks not already reached
+      if (stackInfo.MaxStacks === 0 || stackInfo.CurrentStacks < stackInfo.MaxStacks){
+        this.applyHasteGain(hasteGain);
+        stackInfo.CurrentStacks ++;
+      }
+
+      debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
+    }
+  }
   removeActiveBuff(event) {
     const spellId = event.ability.guid;
-    const hasteGain = this.constructor.HASTE_BUFFS[spellId];
+    let hasteGain = undefined;
+    
+    //Added check so it gets the correct one
+    if (this.constructor.HASTE_BUFFS[spellId]){
+      hasteGain = this.constructor.HASTE_BUFFS[spellId];
+    }
+    else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
+      //When buff loss, it should lose haste equal to base buff haste * number of stacks
+      hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste(this.combatants.selected) * this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks;
+      this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks = 0;
+    }
+
     if (hasteGain) {
       this.applyHasteLoss(hasteGain);
 
@@ -153,7 +207,9 @@ class AlwaysBeCasting extends Module {
   }
 
   static calculateGlobalCooldown(haste) {
-    return 1.5 / (1 + haste);
+    const gcd = 1.5 / (1 + haste);
+    //Check the gcd doesnt go under the limit
+    return gcd > 0.75 ? gcd : 0.75;
   }
   static applyHasteGain(baseHaste, hasteGain) {
     return baseHaste * (1 + hasteGain) + hasteGain;

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -40,9 +40,14 @@ class AlwaysBeCasting extends Module {
     [209165]: -0.3, // DEBUFF - Slow Time from Elisande
     // [208944]: -Infinity, // DEBUFF - Time Stop from Elisande
   };
-
-  //Stackable haste buffs - Set Haste per stack and MaxStacks (0 for no max)
+  
   static STACKABLE_HASTE_BUFFS = {    
+    //Stackable haste buffs - Set Haste per stack and MaxStacks (0 for no max) - See example in Balance Druid ABC
+    //[id] : {
+    //  Haste: (combatant) => (),
+    //  CurrentStacks: 0,
+    //  MaxStacks: 0,
+    //},
   }
 
   totalTimeWasted = 0;

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -138,7 +138,6 @@ class AlwaysBeCasting extends Module {
   on_toPlayer_applybuff(event) {
     this.applyActiveBuff(event);
   }
-  //Added event listener for buff stacks applied
   on_toPlayer_applybuffstack(event){
     this.applyBuffStack(event);
   }
@@ -155,7 +154,6 @@ class AlwaysBeCasting extends Module {
     const spellId = event.ability.guid;
     let hasteGain;
     
-    //Added check so it gets the correct one, and adds stacks if necessary
     if (this.constructor.HASTE_BUFFS[spellId]){
       hasteGain = this.constructor.HASTE_BUFFS[spellId];
     }
@@ -170,7 +168,6 @@ class AlwaysBeCasting extends Module {
       debug && console.log(`ABC: Current haste: ${this.currentHaste} (gained ${hasteGain} from ${spellId})`);
     }
   }
-  //Added apply buff stack event for stackable haste buffs
   applyBuffStack(event) {
     const spellId = event.ability.guid;
     const stackInfo = this.constructor.STACKABLE_HASTE_BUFFS[spellId];
@@ -194,7 +191,6 @@ class AlwaysBeCasting extends Module {
     const spellId = event.ability.guid;
     let hasteLoss;
     
-    //Added check so it gets the correct one
     if (this.constructor.HASTE_BUFFS[spellId]){
       hasteLoss = this.constructor.HASTE_BUFFS[spellId];
     }

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -152,12 +152,9 @@ class AlwaysBeCasting extends Module {
   }
   applyActiveBuff(event) {
     const spellId = event.ability.guid;
-    let hasteGain;
+    let hasteGain = this.constructor.HASTE_BUFFS[spellId] || undefined;
     
-    if (this.constructor.HASTE_BUFFS[spellId]){
-      hasteGain = this.constructor.HASTE_BUFFS[spellId];
-    }
-    else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
+    if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
       hasteGain = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste(this.combatants.selected);
       this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks ++;
     }
@@ -189,12 +186,9 @@ class AlwaysBeCasting extends Module {
   }
   removeActiveBuff(event) {
     const spellId = event.ability.guid;
-    let hasteLoss;
+    let hasteLoss = this.constructor.HASTE_BUFFS[spellId] || undefined;
     
-    if (this.constructor.HASTE_BUFFS[spellId]){
-      hasteLoss = this.constructor.HASTE_BUFFS[spellId];
-    }
-    else if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
+    if (this.constructor.STACKABLE_HASTE_BUFFS[spellId]){
       //When buff loss, it should lose haste equal to base buff haste * number of stacks
       hasteLoss = this.constructor.STACKABLE_HASTE_BUFFS[spellId].Haste(this.combatants.selected) * this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks;
       this.constructor.STACKABLE_HASTE_BUFFS[spellId].CurrentStacks = 0;

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -13,9 +13,10 @@ class AlwaysBeCasting extends Module {
   static ABILITIES_ON_GCD = [
     // Extend this class and override this property in your spec class to implement this module.
   ];
-  static FULLGCD_ABILITIES = [
-    //Override this property in your spec class
-  ];
+  static STATIC_GCD_ABILITIES = {
+    //Abilities which GCD is not affected by haste.
+    //[spellId] : [gcd value in seconds]
+  };
 
   /* eslint-disable no-useless-computed-key */
   static HASTE_BUFFS = { // This includes debuffs
@@ -93,14 +94,14 @@ class AlwaysBeCasting extends Module {
     }
     const spellId = cast.ability.guid;
     const isOnGcd = this.constructor.ABILITIES_ON_GCD.indexOf(spellId) !== -1;
-    const isFullGcd = this.constructor.FULLGCD_ABILITIES.indexOf(spellId) !== -1;
+    //const isFullGcd = this.constructor.FULLGCD_ABILITIES.indexOf(spellId) !== -1;
 
     if (!isOnGcd) {
       debug && console.log(`%cABC: ${cast.ability.name} (${spellId}) ignored`, 'color: gray');
       return;
     }
 
-    const globalCooldown = isFullGcd ? 1500 : this.constructor.calculateGlobalCooldown(this.currentHaste) * 1000;
+    const globalCooldown = this.getCurrentGlobalCooldown(spellId) * 1000 || this.constructor.calculateGlobalCooldown(this.currentHaste) * 1000;
 
     const castStartTimestamp = (begincast ? begincast : cast).timestamp;
 
@@ -217,6 +218,10 @@ class AlwaysBeCasting extends Module {
   }
   applyHasteLoss(hasteGain) {
     this.currentHaste = this.constructor.applyHasteLoss(this.currentHaste, hasteGain);
+  }
+
+  getCurrentGlobalCooldown(spellId) {
+    return this.constructor.STATIC_GCD_ABILITIES[spellId];
   }
 }
 

--- a/src/common/SPELLS_DRUID.js
+++ b/src/common/SPELLS_DRUID.js
@@ -599,6 +599,16 @@ export default {
     name: 'Celestial Alignment',
     icon: 'artifactability_balancedruid_newmoon',
   },
+  ASTRAL_ACCELERATION:{
+    id: 242232,
+    name: 'Astral Acceleration',
+    icon: 'inv_enchant_essenceastrallarge',
+  },
+  STAR_POWER:{
+    id: 202942,
+    name: 'Star Power',
+    icon: 'artifactability_balancedruid_moonandstars',
+  },
   // Feral
   TIGERS_FURY: {
     id: 5217,

--- a/src/common/talents/TALENTS_DRUID.js
+++ b/src/common/talents/TALENTS_DRUID.js
@@ -4,7 +4,7 @@ export default {
   // Shared
   RENEWAL_TALENT: { id: 108238, name: "Renewal", icon: "spell_nature_natureblessing" },
   DISPLACER_BEAST_TALENT: { id: 102280, name: "Displacer Beast", icon: "spell_druid_displacement" },
-  WILD_CHARGE_TALENT: { id: 102401, name: "Wild Charge", icon: "spell_druid_wildcharge" },
+  WILD_CHARGE_TALENT: { id: 102383, name: "Wild Charge", icon: "spell_druid_wildcharge" },
   RESTORATION_AFFINITY_TALENT: { id: 197492, name: "Restoration Affinity", icon: "ability_druid_improvedtreeform" },
   MIGHTY_BASH_TALENT: { id: 5211, name: "Mighty Bash", icon: "ability_druid_bash" },
   MASS_ENTANGLEMENT_TALENT: { id: 102359, name: "Mass Entanglement", icon: "spell_druid_massentanglement" },


### PR DESCRIPTION
It essentially works, Im not completely sure about the placement of some things, any suggestions will be appreciated :D
And maybe too many comments in there, idk.
But well, this should support any specs stackable haste buffs.

Added too a couple silly things:
- Not letting the GCD go under 0.75s, no matter how much haste there is (I think this is true for every spec, if there's any exception should be added here)
- Added the possibility of abilities which GCD is not affected by haste (such as shapeshifting, i dont know it any other class has anything like this)

ToDo:
Add support for trinkets somehow (because haste values change with ilvl)