### PR TITLE
[Destruction] Second batch of talents

### DIFF
--- a/src/Parser/AfflictionWarlock/CHANGELOG.js
+++ b/src/Parser/AfflictionWarlock/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+09-09-2017 - Affliction Warlock: Added Empowered Life Tap module. (by Chizu)
 27-08-2017 - Affliction Warlock: Reworked the DS/UA sniping module to provide more relevant info. (by Chizu)
 24-08-2017 - Affliction Warlock: Added Drain Soul / Unstable Affliction sniping module. (by Chizu)
 21-08-2017 - Affliction Warlock: Added rest of the legendaries (apart from head), some ToS trinkets and T20 set bonuses. (by Chizu)

--- a/src/Parser/AfflictionWarlock/CombatLogParser.js
+++ b/src/Parser/AfflictionWarlock/CombatLogParser.js
@@ -24,6 +24,7 @@ import Haunt from './Modules/Talents/Haunt';
 import MaleficGrasp from './Modules/Talents/MaleficGrasp';
 import Contagion from './Modules/Talents/Contagion';
 import AbsoluteCorruption from './Modules/Talents/AbsoluteCorruption';
+import EmpoweredLifeTap from './Modules/Talents/EmpoweredLifeTap';
 import SoulHarvest from './Modules/Talents/SoulHarvest';
 import SoulHarvestTalent from './Modules/Talents/SoulHarvestTalent';
 import DeathsEmbrace from './Modules/Talents/DeathsEmbrace';
@@ -63,6 +64,7 @@ class CombatLogParser extends CoreCombatLogParser {
     maleficGrasp: MaleficGrasp,
     contagion: Contagion,
     absoluteCorruption: AbsoluteCorruption,
+    empoweredLifeTap: EmpoweredLifeTap,
     soulHarvest: SoulHarvest,
     soulHarvestTalent: SoulHarvestTalent,
     deathsEmbrace: DeathsEmbrace,

--- a/src/Parser/AfflictionWarlock/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/AfflictionWarlock/Modules/Talents/EmpoweredLifeTap.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatNumber, formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+import getDamageBonus from '../WarlockCore/getDamageBonus';
+
+const ELT_DAMAGE_BONUS = 0.1;
+
+class EmpoweredLifeTap extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+  ELTuptime = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.EMPOWERED_LIFE_TAP_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (this.combatants.selected.hasBuff(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id, event.timestamp)) {
+      this.bonusDmg += getDamageBonus(event, ELT_DAMAGE_BONUS);
+    }
+  }
+
+  on_finished() {
+    this.ELTuptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
+  }
+
+  suggestions(when) {
+    when(this.ELTuptime).isLessThan(0.9)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id}/> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id}/> more often.</span>)
+          .icon(SPELLS.EMPOWERED_LIFE_TAP_TALENT.icon)
+          .actual(`${formatPercentage(actual)}% Empowered Life Tap uptime`)
+          .recommended(`>${formatPercentage(recommended)}% is recommended`)
+          .regular(recommended - 0.05).major(recommended - 0.15);
+      });
+  }
+  
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.EMPOWERED_LIFE_TAP_TALENT.id} />}
+        value={`${formatPercentage(this.ELTuptime)} %`}
+        label='Empowered Life Tap uptime'
+        tooltip={`Your Empowered Life Tap talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %)`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
+}
+
+export default EmpoweredLifeTap;

--- a/src/Parser/DestructionWarlock/CHANGELOG.js
+++ b/src/Parser/DestructionWarlock/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+09-09-2017 - Added Reverse Entropy, Eradication and Empowered Life Tap modules. (by Chizu)
 07-09-2017 - Added Immolate uptime tracker. (by Chizu)
 05-09-2017 - Added Soul Shard usage breakdown. (by Chizu)
 04-09-2017 - Fixed the issues with Grimoire of Service and Summon Infernal/Doomguard. (by Chizu) 

--- a/src/Parser/DestructionWarlock/CombatLogParser.js
+++ b/src/Parser/DestructionWarlock/CombatLogParser.js
@@ -14,6 +14,7 @@ import UnusedLordOfFlames from './Modules/Features/UnusedLordOfFlames';
 import GrimoireOfService from './Modules/Features/GrimoireOfService';
 import ImmolateUptime from './Modules/Features/ImmolateUptime';
 
+import ReverseEntropy from './Modules/Talents/ReverseEntropy';
 import SoulShardEvents from './Modules/SoulShards/SoulShardEvents';
 import SoulShardTracker from './Modules/SoulShards/SoulShardTracker';
 import SoulShardDetails from './Modules/SoulShards/SoulShardDetails';
@@ -43,6 +44,7 @@ class CombatLogParser extends CoreCombatLogParser {
     soulShardDetails: SoulShardDetails,
 
     //Talents
+    reverseEntropy: ReverseEntropy,
     soulHarvest: SoulHarvest,
     soulHarvestTalent: SoulHarvestTalent,
 

--- a/src/Parser/DestructionWarlock/CombatLogParser.js
+++ b/src/Parser/DestructionWarlock/CombatLogParser.js
@@ -17,6 +17,8 @@ import ImmolateUptime from './Modules/Features/ImmolateUptime';
 import ReverseEntropy from './Modules/Talents/ReverseEntropy';
 import Eradication from './Modules/Talents/Eradication';
 import EradicationTalent from './Modules/Talents/EradicationTalent';
+import EmpoweredLifeTap from './Modules/Talents/EmpoweredLifeTap';
+
 import SoulShardEvents from './Modules/SoulShards/SoulShardEvents';
 import SoulShardTracker from './Modules/SoulShards/SoulShardTracker';
 import SoulShardDetails from './Modules/SoulShards/SoulShardDetails';
@@ -50,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     reverseEntropy: ReverseEntropy,
     eradication: Eradication,
     eradicationTalent: EradicationTalent,
+    empoweredLifeTap: EmpoweredLifeTap,
     soulHarvest: SoulHarvest,
     soulHarvestTalent: SoulHarvestTalent,
 

--- a/src/Parser/DestructionWarlock/CombatLogParser.js
+++ b/src/Parser/DestructionWarlock/CombatLogParser.js
@@ -15,6 +15,8 @@ import GrimoireOfService from './Modules/Features/GrimoireOfService';
 import ImmolateUptime from './Modules/Features/ImmolateUptime';
 
 import ReverseEntropy from './Modules/Talents/ReverseEntropy';
+import Eradication from './Modules/Talents/Eradication';
+import EradicationTalent from './Modules/Talents/EradicationTalent';
 import SoulShardEvents from './Modules/SoulShards/SoulShardEvents';
 import SoulShardTracker from './Modules/SoulShards/SoulShardTracker';
 import SoulShardDetails from './Modules/SoulShards/SoulShardDetails';
@@ -23,6 +25,7 @@ import DamageDone from './Modules/Features/DamageDone';
 import SoulHarvest from './Modules/Talents/SoulHarvest';
 import SoulHarvestTalent from './Modules/Talents/SoulHarvestTalent';
 
+import SoulOfTheNetherlord from './Modules/Items/Legendaries/SoulOfTheNetherlord';
 import TheMasterHarvester from './Modules/Items/Legendaries/TheMasterHarvester';
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -45,10 +48,13 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Talents
     reverseEntropy: ReverseEntropy,
+    eradication: Eradication,
+    eradicationTalent: EradicationTalent,
     soulHarvest: SoulHarvest,
     soulHarvestTalent: SoulHarvestTalent,
 
     //Legendaries
+    soulOfTheNetherlord: SoulOfTheNetherlord,
     masterHarvester: TheMasterHarvester,
 
     //Items

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/SoulOfTheNetherlord.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/SoulOfTheNetherlord.js
@@ -1,0 +1,28 @@
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import ITEMS from 'common/ITEMS';
+import { formatNumber } from 'common/format';
+
+import Eradication from '../../Talents/Eradication';
+
+class SoulOfTheNetherlord extends Module {
+  static dependencies = {
+    eradication: Eradication,
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasFinger(ITEMS.SOUL_OF_THE_NETHERLORD.id);
+  }
+
+  item() {
+    const bonusDmg = this.eradication.bonusDmg;
+    return {
+      item: ITEMS.SOUL_OF_THE_NETHERLORD,
+      result: `${formatNumber(bonusDmg)} damage - ${this.owner.formatItemDamageDone(bonusDmg)}`,
+    };
+  }
+}
+
+export default SoulOfTheNetherlord;

--- a/src/Parser/DestructionWarlock/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/EmpoweredLifeTap.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatNumber, formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+import getDamageBonus from '../WarlockCore/getDamageBonus';
+
+const ELT_DAMAGE_BONUS = 0.1;
+
+class EmpoweredLifeTap extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+  ELTuptime = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.EMPOWERED_LIFE_TAP_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (this.combatants.selected.hasBuff(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id, event.timestamp)) {
+      this.bonusDmg += getDamageBonus(event, ELT_DAMAGE_BONUS);
+    }
+  }
+
+  on_finished() {
+    this.ELTuptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
+  }
+
+  suggestions(when) {
+    when(this.ELTuptime).isLessThan(0.9)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id}/> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id}/> more often.</span>)
+          .icon(SPELLS.EMPOWERED_LIFE_TAP_TALENT.icon)
+          .actual(`${formatPercentage(actual)}% Empowered Life Tap uptime`)
+          .recommended(`>${formatPercentage(recommended)}% is recommended`)
+          .regular(recommended - 0.05).major(recommended - 0.15);
+      });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.EMPOWERED_LIFE_TAP_TALENT.id} />}
+        value={`${formatPercentage(this.ELTuptime)} %`}
+        label='Empowered Life Tap uptime'
+        tooltip={`Your Empowered Life Tap talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %)`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
+}
+
+export default EmpoweredLifeTap;

--- a/src/Parser/DestructionWarlock/Modules/Talents/Eradication.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/Eradication.js
@@ -1,0 +1,34 @@
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+
+import getDamageBonus from '../WarlockCore/getDamageBonus';
+
+const ERADICATION_DAMAGE_BONUS = 0.15;
+
+//only calculates the bonus damage, output depends if we have the talent directly or via legendary finger (then it appears as either a Statistic or Item)
+class Eradication extends Module {
+  static dependencies = {
+    enemies: Enemies,
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.ERADICATION_TALENT.id) || this.combatants.selected.hasFinger(ITEMS.SOUL_OF_THE_NETHERLORD.id);
+  }
+
+  on_byPlayer_damage(event) {
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy || enemy.hasBuff(SPELLS.ERADICATION_DEBUFF.id, event.timestamp)) {
+      return;
+    }
+    this.bonusDmg += getDamageBonus(event, ERADICATION_DAMAGE_BONUS);
+  }
+}
+
+export default Eradication;

--- a/src/Parser/DestructionWarlock/Modules/Talents/EradicationTalent.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/EradicationTalent.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber, formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+import Eradication from './Eradication';
+
+class ReverseEntropy extends Module {
+  static dependencies = {
+    eradication: Eradication,
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.ERADICATION_TALENT.id);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.ERADICATION_TALENT.id} />}
+        value={`${formatNumber(this.eradication.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
+        label='Damage contributed'
+        tooltip={`Your Eradication talent contributed ${formatNumber(this.eradication.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.eradication.bonusDmg))} %)`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
+}
+
+export default ReverseEntropy;

--- a/src/Parser/DestructionWarlock/Modules/Talents/ReverseEntropy.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/ReverseEntropy.js
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber, formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+import getDamageBonus from '../WarlockCore/getDamageBonus';
+
+const REVERSE_ENTROPY_DAMAGE_BONUS = 0.1;
+
+class ReverseEntropy extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.REVERSE_ENTROPY_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.CHAOS_BOLT.id && event.ability.guid !== SPELLS.RAIN_OF_FIRE_DAMAGE.id) {
+      return;
+    }
+    this.bonusDmg += getDamageBonus(event, REVERSE_ENTROPY_DAMAGE_BONUS);
+  }
+  statistic() {
+    //could show mana returned too, but that's kinda irrelevant for Warlocks anyway
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.REVERSE_ENTROPY_TALENT.id} />}
+        value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
+        label='Damage contributed'
+        tooltip={`Your Reverse Entropy talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %)`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(1);
+}
+
+export default ReverseEntropy;

--- a/src/Parser/DestructionWarlock/Modules/Talents/ReverseEntropy.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/ReverseEntropy.js
@@ -41,7 +41,7 @@ class ReverseEntropy extends Module {
     );
   }
 
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(1);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
 }
 
 export default ReverseEntropy;


### PR DESCRIPTION
Added tier 30 row for Destro talents - Reverse Entropy, Eradication and Empowered Life Tap. Pretty straightforward stuff. Also added the ELT module to Affli since it exists there too (albeit never used I'd say).