### PR TITLE
[Vengeance+Havoc] Cast Efficiency rework

### DIFF
--- a/src/Parser/HavocDemonHunter/CHANGELOG.js
+++ b/src/Parser/HavocDemonHunter/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+09-09-2017 - Some nearly unused abilities and/or no CD abilities now doesn't show 'can be improved' in Cast Efficiency tab. (by Mamtooth)
 07-09-2017 - Abilities now trigger mouseover tooltips on statistic boxes. (by Mamtooth)
 07-09-2017 - Cast Efficiency is now more complete and with more spells tracking. (by Mamtooth)
 07-09-2017 - Dead GCD Time calculation changed to get more abilities. (by Mamtooth)

--- a/src/Parser/HavocDemonHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/HavocDemonHunter/Modules/Features/CastEfficiency.js
@@ -60,26 +60,18 @@ class CastEfficiency extends CoreCastEfficiency {
       extraSuggestion: <span>This is a great AoE damage spell, but also does a great damage on single target. You should cast it as soon as it gets off cooldown. The only moment you can delay it's cast is if you already expect an add wave to maximize it's efficiency and damage output. </span>,
     },
     {
-      spell: SPELLS.FEL_BARRAGE_TALENT,
-      isActive: combatant => combatant.hasTalent(SPELLS.FEL_BARRAGE_TALENT.id),
-      category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-      getCooldown: haste => 60,
-      recommendedCastEfficiency: 0.85,
-      extraSuggestion: <span>This is a great AoE damage spell, but also does a great damage on single target. You should cast it as soon as it gets off cooldown. The only moment you can delay it's cast is if you already expect an add wave to maximize it's efficiency and damage output. </span>,
-    },
-    {
       spell: SPELLS.CHAOS_STRIKE,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => 3,
-      recommendedCastEfficiency: 0.8,
+      getCooldown: haste => null,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
     {
       spell: SPELLS.ANNIHILATION,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => 14,
-      recommendedCastEfficiency: 0.8,
+      getCooldown: haste => null,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
     {
       spell: SPELLS.BLADE_DANCE,
@@ -91,9 +83,9 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.DEATH_SWEEP,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => 45,
-      recommendedCastEfficiency: 0.8,
+      getCooldown: haste => null,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
     {
       spell: SPELLS.METAMORPHOSIS_HAVOC,
@@ -113,8 +105,8 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.THROW_GLAIVE_HAVOC,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 10,
-      recommendedCastEfficiency: 0.5,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
     {
       spell: SPELLS.VENGEFUL_RETREAT,

--- a/src/Parser/VengeanceDemonHunter/CHANGELOG.js
+++ b/src/Parser/VengeanceDemonHunter/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+09-09-2017 - Some nearly unused abilities and/or no CD abilities now doesn't show 'can be improved' in Cast Efficiency tab. (by Mamtooth)
 07-09-2017 - Abilities now trigger mouseover tooltips on statistic boxes. (by Mamtooth)
 07-09-2017 - Updated timers in the statistics tooltips. (by Mamtooth)
 06-09-2017 - Added more suggestions to Immolation Aura buff uptime. (by Mamtooth)

--- a/src/Parser/VengeanceDemonHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/VengeanceDemonHunter/Modules/Features/CastEfficiency.js
@@ -98,13 +98,13 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.EMPOWER_WARDS,
       category: CastEfficiency.SPELL_CATEGORIES.DEFENSIVE,
       getCooldown: haste => 20,
-      recommendedCastEfficiency: 0.50,
+      recommendedCastEfficiency: 0.20,
       noSuggestion: true,
     },
     {
       spell: SPELLS.FIERY_BRAND,
       category: CastEfficiency.SPELL_CATEGORIES.DEFENSIVE,
-      getCooldown: haste => 20,
+      getCooldown: haste => 60,
       recommendedCastEfficiency: 0.50,
       noSuggestion: true,
     },
@@ -118,16 +118,17 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.THROW_GLAIVE,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => 3,
-      recommendedCastEfficiency: 0.10,
+      getCooldown: haste => null,
       noSuggestion: true,
+      noCanBeImproved: true,
+      hideWithZeroCasts: true,
     },
     {
       spell: SPELLS.SHEAR,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => 3,
-      recommendedCastEfficiency: 0.70,
+      getCooldown: haste => null,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
   ];
 }

--- a/src/common/SPELLS_DEMON_HUNTER.js
+++ b/src/common/SPELLS_DEMON_HUNTER.js
@@ -39,7 +39,7 @@ export default {
     name :'Sever',
     icon: 'ability_demonhunter_manabreak',
   },
-  
+
   // Abilities:
   SOUL_FRAGMENT: {
     id: 204255,
@@ -63,7 +63,7 @@ export default {
   },
   SIGIL_OF_FLAME_DEBUFF: {
       id: 204598,
-      name: 'Sigil of Flame Debuff',
+      name: 'Sigil of Flame',
       icon: 'ability_demonhunter_sigilofinquisition',
   },
   SIGIL_OF_MISERY: {


### PR DESCRIPTION
Cast Efficiency is now less nitpicky: Some almost unused abilities or no CD abilities 'can be improved' warning is now disabled.

Also, corrected some getCooldown timers that was wrong in Vengeance CastEfficiency.