### PR TITLE
[Havoc] Update Cast Efficiency

### DIFF
--- a/src/Parser/HavocDemonHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/HavocDemonHunter/Modules/Features/CastEfficiency.js
@@ -24,8 +24,8 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.EYE_BEAM,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 45,
-      recommendedCastEfficiency: 0.40,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
     {
       spell: SPELLS.NEMESIS_TALENT,

--- a/src/Parser/HavocDemonHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/HavocDemonHunter/Modules/Features/CastEfficiency.js
@@ -112,8 +112,8 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.VENGEFUL_RETREAT,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 25,
-      recommendedCastEfficiency: 0.5,
       noSuggestion: true,
+      noCanBeImproved: true,
     },
   ];
 }


### PR DESCRIPTION
Vengeful Retreat does not show 'can be improved' anymore, as it is a really unused movement spell.
Eye Beam does not show 'can be improved' anymore, as it is a very situational spell.