### PR TITLE
Disc Priest: Added Atonement sources breakdown

### DIFF
--- a/src/Main/Event.js
+++ b/src/Main/Event.js
@@ -70,6 +70,11 @@ class Event extends React.PureComponent {
               {formatThousands(event.amount)} {event.absorbed ? <span className="absorbed">(A: {formatThousands(event.absorbed)})</span> : null} {event.overheal ? <span className="overheal">(O: {formatThousands(event.overheal)})</span> : null}
             </span>
           )}
+          {event.type === 'absorbed' && (
+            <span className={event.type}>
+              A: {formatThousands(event.amount)}
+            </span>
+          )}
         </td>
       </tr>
     );

--- a/src/Parser/Core/Modules/HealingDone.js
+++ b/src/Parser/Core/Modules/HealingDone.js
@@ -2,13 +2,7 @@ import Module from 'Parser/Core/Module';
 
 import HealingValue from './HealingValue';
 
-import ManaValues from './ManaValues';
-
 class HealingDone extends Module {
-  static dependencies = {
-    manaValues: ManaValues,
-  };
-
   _total = new HealingValue(); // consider this "protected", so don't change this from other modules. If you want special behavior you must add that code to an extended version of this module.
   get total() {
     return this._total;

--- a/src/Parser/DisciplinePriest/CHANGELOG.js
+++ b/src/Parser/DisciplinePriest/CHANGELOG.js
@@ -1,25 +1,25 @@
 export default `
-22-07-2017 - Disc Priest: Added mana saved from the legendary Inner Hallation. (by hassebewlen)
-18-06-2017 - Disc Priest: Added Touch of the Grave statistic. (by Zerotorescue)
-17-06-2017 - Disc Priest: Evangelism casts are now also shown under the cooldowns tab. Rapture now shows the total abosrbs applied and the amount of damage absorbed. Fixed a few issues that caused too much healing to be assigned to Evangelism. (by Zerotorescue)
-15-06-2017 - Disc Priest: Fixed Wasted Penance bolts always assumed user had the Castigation talent. (by Zerotorescue)
-15-06-2017 - Disc Priest: Disabled suggestions for Pain Suppression and Power Word: Barrier. (by Zerotorescue)
-11-06-2017 - Disc Priest: Added extra suggestion to Power Word: Shield description to add distinction to casts during Rapture. (by milesoldenburg)
-05-06-2017 - Disc Priest: Fix Atonement duration in cast efficiency not accounting for the Doomsayer trait. (by Zerotorescue)
-29-05-2017 - Disc Priest: Show Rapture PW:S casts seperate from regular PW:S casts in Cast Efficiency. (by Zerotorescue)
-28-05-2017 - Disc Priest: Added unused Power Word: Shield absorb statistic.
-25-05-2017 - Disc Priest: Added <i>Early Atonement refreshes</i> statistic. Fixed Skjoldr sometimes not working properly. Both contributions were created by <b>@Shadowdrizz</b>. Thanks a lot for your contribution!
-Disc Priest: Fix Shadowfiend showing with the Mindbender talent.
-18-05-2017 - Disc Priest: Added Shadow Word: Pain/Purge the Wicked global uptime statistic.
-17-05-2017 - Disc Priest: Added Twist of Fate healing statistic (damage gain is in the tooltip).
-16-05-2017 - Disc Priest: Added N'ero, Band of Promises statistic.
-15-05-2017 - Disc Priest: Added Xalan the Feared's Clench statistic.
-15-05-2017 - Disc Priest: Skjoldr, Sanctuary of Ivagont statistic now includes the healing gained via Share in the Light.
-14-05-2017 - Disc Priest: Added Skjoldr, Sanctuary of Ivagont statistic. This does not yet include the healing gained via Share in the Light.
-14-05-2017 - Disc Priest: Added Cord of Maiev, Priestess of the Moon statistic.
+14-09-2017 - Added atonement sources breakdown. This isn't very accurate yet, it's just showing the way it's assigned right now. Improved accuracy will come later. (by Zerotorescue)
+22-07-2017 - Added mana saved from the legendary Inner Hallation. (by hassebewlen)
+18-06-2017 - Added Touch of the Grave statistic. (by Zerotorescue)
+17-06-2017 - Evangelism casts are now also shown under the cooldowns tab. Rapture now shows the total abosrbs applied and the amount of damage absorbed. Fixed a few issues that caused too much healing to be assigned to Evangelism. (by Zerotorescue)
+15-06-2017 - Fixed Wasted Penance bolts always assumed user had the Castigation talent. (by Zerotorescue)
+15-06-2017 - Disabled suggestions for Pain Suppression and Power Word: Barrier. (by Zerotorescue)
+11-06-2017 - Added extra suggestion to Power Word: Shield description to add distinction to casts during Rapture. (by milesoldenburg)
+05-06-2017 - Fix Atonement duration in cast efficiency not accounting for the Doomsayer trait. (by Zerotorescue)
+29-05-2017 - Show Rapture PW:S casts seperate from regular PW:S casts in Cast Efficiency. (by Zerotorescue)
+28-05-2017 - Added unused Power Word: Shield absorb statistic.
+25-05-2017 - Added <i>Early Atonement refreshes</i> statistic. Fixed Skjoldr sometimes not working properly. Both contributions were created by <b>@Shadowdrizz</b>. Thanks a lot for your contribution!
+Fix Shadowfiend showing with the Mindbender talent.
+18-05-2017 - Added Shadow Word: Pain/Purge the Wicked global uptime statistic.
+17-05-2017 - Added Twist of Fate healing statistic (damage gain is in the tooltip).
+16-05-2017 - Added N'ero, Band of Promises statistic.
+15-05-2017 - Added Xalan the Feared's Clench statistic.
+15-05-2017 - Skjoldr, Sanctuary of Ivagont statistic now includes the healing gained via Share in the Light.
+14-05-2017 - Added Skjoldr, Sanctuary of Ivagont statistic. This does not yet include the healing gained via Share in the Light.
+14-05-2017 - Added Cord of Maiev, Priestess of the Moon statistic.
 14-05-2017 - Added Disc Priest 2 set bonus statistic.
-14-05-2017 - Disc Priest: Renamed <i>Missed penance hits</i> to <i>Wasted Penance bolts</i>. <i>Wasted Penance bolts</i> now accounts for (combat log) latency. Fixed Glyph of the Sha's Shadowfiend not being counted towards Shadowfiend casts. Fixed healing increases (most notably the 15% from Velen's) not working with Disc priest spells.
+14-05-2017 - Renamed <i>Missed penance hits</i> to <i>Wasted Penance bolts</i>. <i>Wasted Penance bolts</i> now accounts for (combat log) latency. Fixed Glyph of the Sha's Shadowfiend not being counted towards Shadowfiend casts. Fixed healing increases (most notably the 15% from Velen's) not working with Disc priest spells.
 05-06-2017 - Discipline Priest: Fixed issue where critical atonement healing was not being counted, fixed Nero's Band of Promises being broken. (By Reglitch)
 14-05-2017 - Added Discipline Priest spec. Currently includes basic statistics for Dead GCD time (should be fully operational), shared legendaries, missed Penance hits, cast efficiencies and the other build in tools.
-
 `;

--- a/src/Parser/DisciplinePriest/CombatLogParser.js
+++ b/src/Parser/DisciplinePriest/CombatLogParser.js
@@ -25,6 +25,7 @@ import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import PowerWordShieldWasted from './Modules/Features/PowerWordShieldWasted';
 import AtonementSource from './Modules/Features/AtonementSource';
+import AtonementHealingDone from './Modules/Features/AtonementHealingDone';
 import PowerWordBarrier from './Modules/Features/PowerWordBarrier';
 import LeniencesReward from './Modules/Features/LeniencesReward';
 
@@ -91,6 +92,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldownTracker: CooldownTracker,
     powerWordShieldWasted: PowerWordShieldWasted,
     atonementSource: AtonementSource,
+    atonementHealingDone: AtonementHealingDone,
     powerWordBarrier: PowerWordBarrier,
     leniencesReward: LeniencesReward,
 

--- a/src/Parser/DisciplinePriest/Modules/Features/AtonementHealingBreakdown.js
+++ b/src/Parser/DisciplinePriest/Modules/Features/AtonementHealingBreakdown.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from 'common/Icon';
+import SpellLink from 'common/SpellLink';
+
+class AtonementHealingBreakdown extends React.Component {
+  static propTypes = {
+    total: PropTypes.object.isRequired,
+    bySource: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { total, bySource } = this.props;
+
+    const highestHealing = Object.keys(bySource)
+      .map(key => bySource[key])
+      .reduce((highest, source) => Math.max(highest, source.healing.effective), 1);
+
+    return (
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th colSpan="2">Healing done</th>
+          </tr>
+        </thead>
+        <tbody>
+          {bySource && Object.keys(bySource)
+            .sort((a, b) => bySource[b].healing.effective - bySource[a].healing.effective)
+            .map(spellId => {
+              const { ability, healing } = bySource[spellId];
+
+              const performanceBarPercentage = healing.effective / highestHealing;
+
+              return (
+                <tr key={ability.guid}>
+                  <td style={{ width: '30%' }}>
+                    <SpellLink id={ability.guid}>
+                      <Icon icon={ability.abilityIcon} />{' '}
+                      {ability.name}
+                    </SpellLink>
+                  </td>
+                  <td style={{ width: 50, paddingRight: 5, textAlign: 'right' }}>
+                    {(Math.round(healing.effective / total.effective * 10000) / 100).toFixed(2)}%
+                  </td>
+                  <td style={{ width: '70%' }}>
+                    <div
+                      className={`performance-bar`}
+                      style={{ width: `${performanceBarPercentage * 100}%` }}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    );
+  }
+}
+
+export default AtonementHealingBreakdown;

--- a/src/Parser/DisciplinePriest/Modules/Features/AtonementHealingBreakdown.js
+++ b/src/Parser/DisciplinePriest/Modules/Features/AtonementHealingBreakdown.js
@@ -45,6 +45,7 @@ class AtonementHealingBreakdown extends React.Component {
                     {(Math.round(healing.effective / total.effective * 10000) / 100).toFixed(2)}%
                   </td>
                   <td style={{ width: '70%' }}>
+                    {/*TODO: Color the bar based on the damage type, physical = yellow, chaos = gradient, etc. idk */}
                     <div
                       className={`performance-bar`}
                       style={{ width: `${performanceBarPercentage * 100}%` }}

--- a/src/Parser/DisciplinePriest/Modules/Features/AtonementHealingDone.js
+++ b/src/Parser/DisciplinePriest/Modules/Features/AtonementHealingDone.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import Tab from 'Main/Tab';
+import Module from 'Parser/Core/Module';
+import HealingValue from 'Parser/Core/Modules/HealingValue';
+
+import isAtonement from '../Core/isAtonement';
+import AtonementSource from './AtonementSource';
+import AtonementHealingBreakdown from './AtonementHealingBreakdown';
+
+class AtonementHealingDone extends Module {
+  static dependencies = {
+    atonementSource: AtonementSource,
+  };
+
+  _total = new HealingValue();
+  get total() {
+    return this._total;
+  }
+  bySource = {};
+
+  on_byPlayer_heal(event) {
+    if (!isAtonement(event)) {
+      return;
+    }
+    const source = this.atonementSource.atonementDamageSource;
+    this._addHealing(source, event.amount, event.absorbed, event.overheal);
+  }
+  _addHealing(source, amount = 0, absorbed = 0, overheal = 0) {
+    const ability = source.ability;
+    const spellId = ability.guid;
+    this._total = this._total.add(amount, absorbed, overheal);
+    this.bySource[spellId] = this.bySource[spellId] || {};
+    this.bySource[spellId].ability = ability;
+    this.bySource[spellId].healing = (this.bySource[spellId].healing || new HealingValue()).add(amount, absorbed, overheal);
+  }
+
+  tab() {
+    return {
+      title: 'Atonement sources',
+      url: 'atonement-sources',
+      render: () => (
+        <Tab title="Atonement sources">
+          <AtonementHealingBreakdown
+            total={this.total}
+            bySource={this.bySource}
+          />
+        </Tab>
+      ),
+    };
+  }
+}
+
+export default AtonementHealingDone;

--- a/src/Parser/DisciplinePriest/Modules/Features/AtonementSource.js
+++ b/src/Parser/DisciplinePriest/Modules/Features/AtonementSource.js
@@ -1,5 +1,4 @@
 import SPELLS from 'common/SPELLS';
-
 import Module from 'Parser/Core/Module';
 
 class AtonementSource extends Module {


### PR DESCRIPTION
Added an *Atonement sources* tab;

![image](https://user-images.githubusercontent.com/4565223/30453678-e81e7350-9999-11e7-9008-471dad3dc78a.png)

I wanted to see if I could get the atonement source tracking as accurate as beacon heal source tracking by using the same method and I figured this would be easier to do with a way to see the result. This does that. This display will always be as accurate as the tracking by the AtonementSource module and the accuracy of the shown data isn't related to changes in this PR.