### PR TITLE
[Vengeance] Spirit Bomb statistics and Soul Fragments tracker

### DIFF
--- a/src/Parser/VengeanceDemonHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/VengeanceDemonHunter/Modules/Features/CastEfficiency.js
@@ -12,7 +12,7 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.IMMOLATION_AURA,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 15 / (1 + haste),
-      recommendedCastEfficiency: 0.95,
+      recommendedCastEfficiency: 0.8,
       extraSuggestion: <span>This is a great Pain filler spell. Try to always cast it on cooldown, specially when using <ItemLink id={ITEMS.KIREL_NARAK.id} /> legendary to trigger it's passive and/or using the <SpellLink id={SPELLS.FALLOUT_TALENT.id} /> talent in order to maximize your <SpellLink id={SPELLS.SOUL_FRAGMENT.id} /> generation. </span>,
     },
     {
@@ -20,7 +20,7 @@ class CastEfficiency extends CoreCastEfficiency {
       isActive: combatant => (combatant.hasTalent(SPELLS.FLAME_CRASH_TALENT.id) || combatant.hasWrists(ITEMS.THE_DEFILERS_LOST_VAMBRACES.id)),
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 9,
-      recommendedCastEfficiency: 0.9,
+      recommendedCastEfficiency: 0.75,
       extraSuggestion: <span>This is a great fire DoT spell. Try to always cast it on cooldown, specially when using <SpellLink id={SPELLS.FLAME_CRASH_TALENT.id} /> talent to apply it just by using <SpellLink id={SPELLS.INFERNAL_STRIKE.id} /> ability and/or using the <ItemLink id={ITEMS.THE_DEFILERS_LOST_VAMBRACES.id} /> legendary to reduce it's cooldown. </span>,
     },
     {
@@ -28,7 +28,7 @@ class CastEfficiency extends CoreCastEfficiency {
       isActive: combatant => !(combatant.hasTalent(SPELLS.FLAME_CRASH_TALENT.id) || combatant.hasWrists(ITEMS.THE_DEFILERS_LOST_VAMBRACES.id)),
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 30 / (1 + haste),
-      recommendedCastEfficiency: 0.8,
+      recommendedCastEfficiency: 0.5,
       extraSuggestion: <span>This is a great fire DoT spell. Try to always cast it on cooldown. </span>,
     },
     {
@@ -53,14 +53,6 @@ class CastEfficiency extends CoreCastEfficiency {
       getCooldown: haste => 40,
       recommendedCastEfficiency: 0.9,
       extraSuggestion: <span>This is your cooldown <SpellLink id={SPELLS.SOUL_FRAGMENT.id} /> generator spell and it does the higher damage / casting time of all your abilities. The only moment you can delay it's cast is if you already have 5 unused <SpellLink id={SPELLS.SOUL_FRAGMENT.id} /> or if you are waiting for a damage burst combo with <SpellLink id={SPELLS.FIERY_BRAND.id} /> (with the <SpellLink id={SPELLS.FIERY_DEMISE.id} /> artifact trait). </span>,
-    },
-    {
-      spell: SPELLS.FRACTURE_TALENT,
-      isActive: combatant => combatant.hasTalent(SPELLS.FRACTURE_TALENT.id),
-      category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => 5,
-      recommendedCastEfficiency: 0.7,
-      extraSuggestion: <span>This is your main <SpellLink id={SPELLS.SOUL_FRAGMENT.id} /> generator spell and it does a single target DPS increase by just 30 Pain per cast. The only moment you can delay it's cast is if you already have 5 unused <SpellLink id={SPELLS.SOUL_FRAGMENT.id} />. </span>,
     },
     {
       spell: SPELLS.FELBLADE_TALENT,
@@ -102,6 +94,14 @@ class CastEfficiency extends CoreCastEfficiency {
       noSuggestion: true,
     },
     {
+        spell: SPELLS.FRACTURE_TALENT,
+        isActive: combatant => combatant.hasTalent(SPELLS.FRACTURE_TALENT.id),
+        category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
+        getCooldown: haste => null,
+        noSuggestion: true,
+        noCanBeImproved: true,
+    },
+    {
       spell: SPELLS.FIERY_BRAND,
       category: CastEfficiency.SPELL_CATEGORIES.DEFENSIVE,
       getCooldown: haste => 60,
@@ -125,6 +125,13 @@ class CastEfficiency extends CoreCastEfficiency {
     },
     {
       spell: SPELLS.SHEAR,
+      category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
+      getCooldown: haste => null,
+      noSuggestion: true,
+      noCanBeImproved: true,
+    },
+    {
+      spell: SPELLS.SOUL_CLEAVE,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => null,
       noSuggestion: true,

--- a/src/Parser/VengeanceDemonHunter/Modules/Statistics/SoulFragments/SoulFragments.js
+++ b/src/Parser/VengeanceDemonHunter/Modules/Statistics/SoulFragments/SoulFragments.js
@@ -4,6 +4,7 @@ import Module from 'Parser/Core/Module';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 
 import { formatNumber } from 'common/format';
@@ -14,17 +15,61 @@ class SoulFragments extends Module {
     abilityTracker: AbilityTracker,
   }
 
+  generated = 0;
+  wasted = 0;
+  spent = 0;
+  actual = 0;
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.SOUL_FRAGMENT.id) {
+    this.generated += 1;
+      if(this.actual < 5) {
+        this.actual += 1;
+      }
+      else {
+        this.wasted += 1;
+      }
+    }
+  }
+
+  on_byPlayer_removebuffstack(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.SOUL_FRAGMENT_STACK.id) {
+      this.spent += 1;
+      this.actual -= 1;
+    }
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.SOUL_FRAGMENT_STACK.id) {
+      this.spent += 1;
+      this.actual -= 1;
+    }
+  }
+
+  suggestions(when) {
+    const wasterPerGenerated = this.wasted / this.generated;
+    const maximumWaste = Math.floor(0.15 * this.generated);
+
+    when(wasterPerGenerated).isGreaterThan(0.15)
+    .addSuggestion((suggest, actual, recommended) => {
+      return suggest(<span>You are wasting <SpellLink id={SPELLS.SOUL_FRAGMENT.id} />. Try to not let them cap by using <SpellLink id={SPELLS.SPIRIT_BOMB_TALENT.id} /> and/or <SpellLink id={SPELLS.SOUL_CLEAVE.id} /> to spend it. The only moment you should let them cap is when you are waiting to use <SpellLink id={SPELLS.SOUL_BARRIER_TALENT.id} /> to mitigate heavy incoming damage. </span>)
+        .icon('spell_shadow_soulgem')
+        .actual(`${formatNumber(this.wasted)} wasted Soul Fragments.`)
+        .recommended(`<=${formatNumber(maximumWaste)} is recommended`)
+        .regular(recommended + 0.03).major(recommended + 0.05);
+    });
+  }
+
   statistic() {
-    const soulFragmentsCasts = this.abilityTracker.getAbility(SPELLS.SOUL_FRAGMENT.id).casts;
-
-    const soulFragmentsCastsPerMinutes = (soulFragmentsCasts / this.owner.fightDuration) * 1000 * 60;
-
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.SOUL_FRAGMENT.id} />}
-        value={`${formatNumber(soulFragmentsCastsPerMinutes)}`}
-        label='Soul Fragments per minute'
-        tooltip={`The total Soul Fragments generated was ${formatNumber(soulFragmentsCasts)}.`}
+        value={`${formatNumber(this.wasted)}`}
+        label='Soul Fragments wasted'
+        tooltip={`The total Soul Fragments generated was ${formatNumber(this.generated)}.<br/>The total Soul Fragments spent was ${formatNumber(this.spent)}.<br/>The total Soul Fragments wasted was ${formatNumber(this.wasted)}.<br/>At the end of the fight, you had ${formatNumber(this.actual)} unused Soul Fragments.`}
       />
     );
   }

--- a/src/Parser/VengeanceDemonHunter/Modules/Statistics/SpiritBomb/SpiritBomb.js
+++ b/src/Parser/VengeanceDemonHunter/Modules/Statistics/SpiritBomb/SpiritBomb.js
@@ -1,16 +1,22 @@
 import React from 'react';
 
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
 import Module from 'Parser/Core/Module';
 
 import { formatPercentage } from 'common/format';
+import { formatThousands } from 'common/format';
+import { formatDuration } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class SpiritBomb extends Module {
   static dependencies = {
+    abilityTracker: AbilityTracker,
     combatants: Combatants,
     enemies: Enemies,
   }
@@ -22,7 +28,7 @@ class SpiritBomb extends Module {
   suggestions(when) {
     const spiritBombUptimePercentage = this.enemies.getBuffUptime(SPELLS.FRAILTY_SPIRIT_BOMB_DEBUFF.id) / this.owner.fightDuration;
 
-    when(spiritBombUptimePercentage).isLessThan(0.95)
+    when(spiritBombUptimePercentage).isLessThan(0.90)
     .addSuggestion((suggest, actual, recommended) => {
       return suggest(<span>Try to cast <SpellLink id={SPELLS.SPIRIT_BOMB_TALENT.id} /> more often. This is your core healing ability by applying <SpellLink id={SPELLS.FRAILTY_SPIRIT_BOMB_DEBUFF.id} /> debuff. Try to refresh it even if you have just one <SpellLink id={SPELLS.SOUL_FRAGMENT.id} /> available.</span>)
         .icon('inv_icon_shadowcouncilorb_purple')
@@ -31,6 +37,24 @@ class SpiritBomb extends Module {
         .regular(recommended - 0.05).major(recommended - 0.15);
     });
   }
+
+  statistic() {
+    const spiritBombUptime = this.enemies.getBuffUptime(SPELLS.FRAILTY_SPIRIT_BOMB_DEBUFF.id);
+
+    const spiritBombUptimePercentage = spiritBombUptime / this.owner.fightDuration;
+
+    const spiritBombDamage = this.abilityTracker.getAbility(SPELLS.SPIRIT_BOMB_DAMAGE.id).damageEffective;
+
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SPIRIT_BOMB_TALENT.id} />}
+        value={`${formatPercentage(spiritBombUptimePercentage)}%`}
+        label='Spirit Bomb debuff Uptime'
+        tooltip={`The Spirit Bomb total damage was ${formatThousands(spiritBombDamage)}.<br/>The Spirit Bomb total uptime was ${formatDuration(spiritBombUptime / 1000)}.`}
+      />
+    );
+  }
+   statisticOrder = STATISTIC_ORDER.CORE(10);
 }
 
 export default SpiritBomb;

--- a/src/common/SPELLS_DEMON_HUNTER.js
+++ b/src/common/SPELLS_DEMON_HUNTER.js
@@ -46,6 +46,11 @@ export default {
     name: 'Soul Fragment',
     icon: 'spell_shadow_soulgem',
   },
+  SOUL_FRAGMENT_STACK: {
+    id: 203981,
+    name: 'Soul Fragment',
+    icon: 'spell_shadow_soulgem',
+  },
   EMPOWER_WARDS: {
     id: 218256,
     name: 'Empower Wards',
@@ -201,6 +206,11 @@ export default {
   FRAILTY_SPIRIT_BOMB_DEBUFF: {
     id: 247456,
     name: 'Frailty',
+    icon: 'inv_icon_shadowcouncilorb_purple',
+  },
+  SPIRIT_BOMB_DAMAGE: {
+    id: 247455,
+    name: 'Spirit Bomb',
     icon: 'inv_icon_shadowcouncilorb_purple',
   },
   FELBLADE_PAIN_GENERATION: {


### PR DESCRIPTION
- Spirit Bomb debuff now have a statistic box to show the uptime as well.
- Soul Fragments statistics is now more complete: it shows the total generated/spent/wasted/unused Soul Fragments of a fight.
- Soul Fragments suggestions for wasting it is now created too.
