### PR TITLE
[Core] Added Archimonde's Hatred Reborn DPS meters on tooltip

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+16-09-2017 - Archimonde's Hatred Reborn now shows total damage done % and DPS contribution on it's tooltip. (by Mamtooth)
 12-09-2017 - The Always Be Casting module has the following changes:
 <ul>
   <li>It now properly supports the passive Haste gain from Sephuz.</li>

--- a/src/Parser/Core/Modules/Items/ArchimondesHatredReborn.js
+++ b/src/Parser/Core/Modules/Items/ArchimondesHatredReborn.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 
@@ -10,6 +12,7 @@ class ArchimondesHatredReborn extends Module {
   };
 
   healing = 0;
+  damage = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.ARCHIMONDES_HATRED_REBORN.id);
@@ -22,10 +25,23 @@ class ArchimondesHatredReborn extends Module {
     }
   }
 
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.ARCHIMONDES_HATRED_REBORN_DAMAGE.id) {
+      this.damage += event.amount;
+    }
+  }
+
   item() {
     return {
       item: ITEMS.ARCHIMONDES_HATRED_REBORN,
-      result:`${this.owner.formatItemHealingDone(this.healing)}`,
+      result: (
+          <dfn data-tip={`The effective absorb and damage contributed by Archimode's Hatred Reborn.<br/>
+              Damage: ${this.owner.formatItemDamageDone(this.damage)} <br/>
+              Absorb: ${this.owner.formatItemHealingDone(this.healing)}`}>
+            {this.owner.formatItemHealingDone(this.healing)}
+          </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/VengeanceDemonHunter/CHANGELOG.js
+++ b/src/Parser/VengeanceDemonHunter/CHANGELOG.js
@@ -1,4 +1,6 @@
 export default `
+16-09-2017 - Created a Soul Fragments tracker (with total generated/spent/wasted/unused) and improvement suggestion for wasted Soul Fragments. (by Mamtooth)
+16-09-2017 - Spirit Bomb is now on statistics boxes too. (by Mamtooth)
 09-09-2017 - Some nearly unused abilities and/or no CD abilities now doesn't show 'can be improved' in Cast Efficiency tab. (by Mamtooth)
 07-09-2017 - Abilities now trigger mouseover tooltips on statistic boxes. (by Mamtooth)
 07-09-2017 - Updated timers in the statistics tooltips. (by Mamtooth)

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -242,6 +242,11 @@ export default {
     name: 'Archimonde\'s Hatred Reborn',
     icon: 'spell_nature_elementalshields',
   },
+  ARCHIMONDES_HATRED_REBORN_DAMAGE: {
+    id: 235188,
+    name: 'Archimonde\'s Hatred Reborn',
+    icon: 'spell_nature_elementalshields',
+  },
   DRUMS_OF_FURY: {
     id: 178207,
     name: 'Drums of Fury',


### PR DESCRIPTION
I inserted the DPS contribution to the Archimonde's Hatred Reborn legendary. It was a suggestion from a theorycrafter player in order to keep track of it maximum damage possible and DPS meters for it.

![image](https://user-images.githubusercontent.com/12674637/30514381-fe9593e2-9ae9-11e7-99df-19fb207489ca.png)
