### PR TITLE
[core] byAbility and byMagicSchool no longer return undefined when no entry yet

### DIFF
--- a/src/Parser/Core/Modules/DamageTaken.js
+++ b/src/Parser/Core/Modules/DamageTaken.js
@@ -24,17 +24,19 @@ class DamageTaken extends Module {
   _byAbility = {};
   byAbility(spellId) {
     if(!this._byAbility[spellId]) {
-      this._byAbility[spellId] = new DamageValue(0, 0, 0);
+      return new DamageValue(0, 0, 0);
+    } else {
+      return this._byAbility[spellId];
     }
-    return this._byAbility[spellId];
   }
-  
+
   _byMagicSchool = {};
   byMagicSchool(magicSchool) {
     if(!this._byMagicSchool[magicSchool]) {
-      this._byMagicSchool[magicSchool] = new DamageValue(0, 0, 0);
+      return new DamageValue(0, 0, 0);
+    } else {
+      return this._byMagicSchool[magicSchool];
     }
-    return this._byMagicSchool[magicSchool];
   }
 
   on_toPlayer_damage(event) {

--- a/src/Parser/Core/Modules/DamageTaken.js
+++ b/src/Parser/Core/Modules/DamageTaken.js
@@ -20,12 +20,20 @@ class DamageTaken extends Module {
   get total() {
     return this._total;
   }
+
   _byAbility = {};
   byAbility(spellId) {
+    if(!this._byAbility[spellId]) {
+      this._byAbility[spellId] = new DamageValue(0, 0, 0);
+    }
     return this._byAbility[spellId];
   }
+  
   _byMagicSchool = {};
   byMagicSchool(magicSchool) {
+    if(!this._byMagicSchool[magicSchool]) {
+      this._byMagicSchool[magicSchool] = new DamageValue(0, 0, 0);
+    }
     return this._byMagicSchool[magicSchool];
   }
 

--- a/src/Parser/Core/Modules/HealingDone.js
+++ b/src/Parser/Core/Modules/HealingDone.js
@@ -12,6 +12,9 @@ class HealingDone extends Module {
 
   _byAbility = {};
   byAbility(spellId) {
+    if(!this._byAbility[spellId]) {
+      this._byAbility[spellId] = new HealingValue(0, 0, 0);
+    }
     return this._byAbility[spellId];
   }
 

--- a/src/Parser/Core/Modules/HealingDone.js
+++ b/src/Parser/Core/Modules/HealingDone.js
@@ -13,9 +13,10 @@ class HealingDone extends Module {
   _byAbility = {};
   byAbility(spellId) {
     if(!this._byAbility[spellId]) {
-      this._byAbility[spellId] = new HealingValue(0, 0, 0);
+      return new HealingValue(0, 0, 0);
+    } else {
+      return this._byAbility[spellId];
     }
-    return this._byAbility[spellId];
   }
 
   on_heal(event) {


### PR DESCRIPTION
I tried to use byAbility in HealingDone and was immediately hit by the inconvenience of constant undefined checks. It seems to me that if I call byAbility on something that hasn't healed yet, I should get zeroes, not undefined.

A search of the code revealed that no one has used these util methods in DamageTaken either, so I gave them the same treatment.

By the way, how do you feel about using "if(!object)" to check for undefined? Searching the web for this question, I found a lot of answers for how you *could* check for undefined, but very few about how you *should* check for undefined.