### PR TITLE
[Guardian] Upgrade completeness to 'good'

### DIFF
--- a/src/Parser/GuardianDruid/CONFIG.js
+++ b/src/Parser/GuardianDruid/CONFIG.js
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.GUARDIAN_DRUID,
   maintainer: '@faide',
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };

--- a/src/Parser/GuardianDruid/CONFIG.js
+++ b/src/Parser/GuardianDruid/CONFIG.js
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.GUARDIAN_DRUID,
   maintainer: '@faide',
-  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GREAT, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };


### PR DESCRIPTION
The guardian module currently tracks: (along with standard stuff like Dead GCD time, DPS, HPS, DTPS)
 - Cast Efficiency for all rotational spells (Thrash cooldown tracking needs some improvement)
 - Unused procs (Gore, Galactic Guardian, and Guardian of Elune)
 - Uptimes (Ironfur, Thrash, Moonfire, Pulverize)
 - DPS/HPS contribution for most spec legendaries
 - Rage waste
 - Earthwarden efficiency
 - Frenzied Regeneration efficiency

Modules that are in development or are planned:
 - Anti-filler spam
 - Damage mitigation assessment for all relevant spells, talents, and items
 - Cooldowns tab
 - Multitarget suggestion improvements
 - Efficiency metrics for other talents
 - DPS/HPS contributiosn for remaining legendaries

I'd consider the current status of the Guardian module `Good`. The core rotational spells are all supported (minus filler spam detection), and all relevant uptimes are displayed.  There are multiple in-depth suggestions for improving play unrelated to basic statistics as well.  The planned modules will provide far more in depth analysis, at which point we can consider further upgrading the completeness.  

I'm tracking the status of all Guardian Druid modules here: https://github.com/FaideWW/WoWAnalyzer/projects/1

Let me know what you think!