### PR TITLE
[Destruction] Completeness status

### DIFF
--- a/src/Parser/DestructionWarlock/CONFIG.js
+++ b/src/Parser/DestructionWarlock/CONFIG.js
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.DESTRUCTION_WARLOCK,
   maintainer: '@Chizu',
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD,
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };


### PR DESCRIPTION
This is the list of current Destruction features:
- Immolate uptime
- core modules - AlwaysBeCasting, CastEfficiency, CooldownTracker, DamageDone
- merged the Doomguard/Infernal suggestions from CastEfficiency - those 2 summons are on shared cooldown so this should take that into account 
- merged Grimoire suggestions - same as before, 4 Grimoires share the same cooldown
- Havoc module - currently not as accurate as I'd want it to be, it shows damage done to targets with Havoc (which is correct), but it doesn't distinguish, if that damage was directly from us (us directly targeting the Havoc'd mob) or it was the cleaved one
- Unused Lord of Flames - artifact trait Lord of Flames buffs the Summon Infernal every 10 minutes, and if it's empowered, it's more powerful than Doomguard even on single target, so we should use Infernal whenever we can benefit from it
- Dimensional Rift breakdown - shows damage from each of the rifts - just a statistic, nothing we can do about it as it's random which gets spawned
- items/legendaries
  - Odr, Shawl of the Ymirjar might be inaccurate as I'm not entirely sure of 2 spells that's accounted for, if they're buffed or not (but considering that legendary isn't used at all I'd say it's a minor bug)
  - T20 4p bonus - probably impossible to calculate the real benefit from it (take a look at Destro mastery what it does)
- talents - again, mostly statistic (with some exceptions - Backdraft and Empowered Life Tap add a suggestion as well)
- Soul Shard breakdown - similar to Affliction, this time we had to do it manually because of WCL

As for the future, it's pretty much the same as with Affliction, no feedback, will work on it when I finish Demonology.