### PR TITLE
[Vengeance] Changed Spec Completeness

### DIFF
--- a/src/Parser/VengeanceDemonHunter/CONFIG.js
+++ b/src/Parser/VengeanceDemonHunter/CONFIG.js
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.VENGEANCE_DEMON_HUNTER,
   maintainer: '@Mamtooth',
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };


### PR DESCRIPTION
I actually consider that the Vengeance Demon Hunter spec is quite complete:
- It has several improvement suggestions, which vary with the talents you're using:
    - Spirit Bomb have a separate module to include more accurate statistics and debuff uptime percentage (USP).
    - Core rotation spells have it's own statistic boxes to show the buff uptime and, in Immolation Aura box, it also shows the total damage done by it (calculated both with the buff damage and the first strike damage) (USP).
- It has a Pain Chart to show how much Pain you wasted in the fight and Pain usage breakdown, including the spenders, which are a USP (WCL does not include spenders in it's chart).
- It also have a Soul Fragment wasted tracker, which can't be found anywhere (USP).
- It already have all spells in the cast efficiency tracker, including the Defensive Cooldowns category.

I consider it as 'Good' completeness because there are some things left to implement:
- Tier 20/21 buff tracker.

I was thinking of getting it to Great as soon as I complete this new suggestions, due to the tank DH spec analysis coverage is almost complete (still waiting for more suggestions to implement new things).