### PR TITLE
[Core] Kil'Jaedens Burning Wish cast efficiency removed

### DIFF
--- a/src/Parser/Core/Modules/CastEfficiency.js
+++ b/src/Parser/Core/Modules/CastEfficiency.js
@@ -54,12 +54,12 @@ class CastEfficiency extends Module {
       getCooldown: haste => 180,
       isActive: combatant => combatant.hasFinger(ITEMS.GNAWED_THUMB_RING.id),
     },
-    {
-      spell: SPELLS.KILJAEDENS_BURNING_WISH_CAST,
-      category: CastEfficiency.SPELL_CATEGORIES.ITEMS,
-      getCooldown: haste => 75,
-      isActive: combatant => combatant.hasTrinket(ITEMS.KILJAEDENS_BURNING_WISH.id),
-    },
+    // {
+    //   spell: SPELLS.KILJAEDENS_BURNING_WISH_CAST,
+    //   category: CastEfficiency.SPELL_CATEGORIES.ITEMS,
+    //   getCooldown: haste => 75,
+    //   isActive: combatant => combatant.hasTrinket(ITEMS.KILJAEDENS_BURNING_WISH.id),
+    // },
     {
       spell: SPELLS.ARCHIMONDES_HATRED_REBORN_ABSORB,
       category: CastEfficiency.SPELL_CATEGORIES.ITEMS,


### PR DESCRIPTION
It shows cast efficiency numbers, but this trinket hasn't a cast event on it, so it always show 0 casts per fight, also triggering suggestions and 'can be improved', even if the player has used it off CD.