### PR TITLE
[Core] Included a condition to only show pet damage when is greater than 0

### DIFF
--- a/src/Parser/Core/Modules/DamageDone.js
+++ b/src/Parser/Core/Modules/DamageDone.js
@@ -52,7 +52,7 @@ class DamageDone extends Module {
         )}
         value={`${formatNumber(this.total.effective / (this.owner.fightDuration / 1000))} DPS`}
         label="Damage done"
-        tooltip={`The total damage done was ${formatThousands(this.total.effective)}. Pets contributed ${formatNumber(this.totalByPets.effective / (this.owner.fightDuration / 1000))} DPS.`}
+        tooltip={`${this.totalByPets.effective > 0 ? `The total damage done was ${formatThousands(this.total.effective)}.<br/>Pets contributed ${formatNumber(this.totalByPets.effective / (this.owner.fightDuration / 1000))} DPS.` : `The total damage done was ${formatThousands(this.total.effective)}.`}`}
       />
     );
   }


### PR DESCRIPTION
In DamageDone.js the tooltip was always showing pets damage, even if it was equal to 0. I've included a condition to only show pets DPS contribution when it is higher than 0, in order to only show pets DPS just when you used a pet in the fight.
Demo:
Destruction Warlock damage done tooltip:
![image](https://user-images.githubusercontent.com/12674637/30776134-a511124a-a077-11e7-872c-184001c6d76a.png)
Vengeance Demon Hunter damage done tooltip:
![image](https://user-images.githubusercontent.com/12674637/30776137-b0b47b32-a077-11e7-9903-d3fa04744999.png)
